### PR TITLE
tests: add unit tests and set ci fail under 80 cov

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,10 @@ jobs:
       run: |
         uv sync --extra dev
 
-
     - name: Run linting
       run: |
         make lint
+
+    - name: Run tests
+      run: |
+        uv run pytest --cov=gakido --cov-report=term-missing --cov-fail-under=80

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,14 @@ repos:
         language: system
         pass_filenames: false
 
+  - repo: local
+    hooks:
+      - id: pytest
+        name: pytest
+        entry: make test
+        language: system
+        pass_filenames: false
+
   - repo: https://github.com/compilerla/conventional-pre-commit
     rev: v3.2.0
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,15 @@ dev = [
     "mkdocs-git-revision-date-localized-plugin>=1.5.0",
     "mkdocs-material>=9.7.1",
     "pytest>=9.0.2",
+    "pytest-sugar>=1.1.1",
+    "pytest-asyncio>=1.3.0",
+    "pytest-pretty>=1.3.0",
+    "pytest-picked>=0.5.1",
+    "pytest-timeout>=2.4.0",
+    "pytest-instafail>=0.5.0",
+    "pytest-codspeed>=4.2.0",
+    "pytest-cov>=7.0.0",
+    "respx>=0.22.0",
     "ruff>=0.14.13",
     "ty>=0.0.12",
 ]
@@ -43,6 +52,26 @@ ext-modules = [
 build = "cp311-* cp312-* cp313-*"
 # Skip 32-bit builds and musl
 skip = "*-win32 *-manylinux_i686 *-musllinux_*"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"
+addopts = "-v --tb=short --cov=gakido --cov-report=term-missing --cov-fail-under=80"
+
+[tool.coverage.run]
+source = ["gakido"]
+omit = [
+    "gakido/core.c",
+    "gakido/gakido_core*",
+    "examples/*",
+]
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "if TYPE_CHECKING:",
+    "if __name__ == .__main__.:",
+]
 [tool.ruff]
 # Exclude a variety of commonly ignored directories.
 exclude = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,54 @@
+"""Pytest configuration and fixtures."""
+
+import pytest
+from gakido.models import Response
+
+
+@pytest.fixture
+def sample_response():
+    """Create a sample Response object."""
+    return Response(
+        status_code=200,
+        reason="OK",
+        http_version="1.1",
+        headers=[
+            ("Content-Type", "application/json"),
+            ("Content-Length", "13"),
+        ],
+        body=b'{"key":"val"}',
+    )
+
+
+@pytest.fixture
+def sample_profile():
+    """Create a sample browser profile."""
+    return {
+        "tls": {
+            "ciphers": "TLS_AES_128_GCM_SHA256",
+            "alpn": ["h2", "http/1.1"],
+            "curves": ["X25519"],
+        },
+        "http2": {
+            "settings": {"HEADER_TABLE_SIZE": 65536},
+            "alpn": ["h2", "http/1.1"],
+        },
+        "http3": {
+            "max_stream_data": 1048576,
+            "max_data": 10485760,
+            "idle_timeout": 30.0,
+        },
+        "headers": {
+            "order": ["Host", "User-Agent", "Accept"],
+            "default": [
+                ("User-Agent", "TestAgent/1.0"),
+                ("Accept", "*/*"),
+                ("Accept-Encoding", "gzip, deflate, br"),
+            ],
+        },
+    }
+
+
+@pytest.fixture
+def mock_socket(mocker):
+    """Create a mock socket."""
+    return mocker.MagicMock()

--- a/tests/test_aio.py
+++ b/tests/test_aio.py
@@ -1,0 +1,690 @@
+"""Tests for gakido.aio module (AsyncClient)."""
+
+import pytest
+from unittest.mock import Mock, patch, MagicMock, AsyncMock
+import asyncio
+import ssl
+
+from gakido.aio import AsyncClient
+from gakido.models import Response
+from gakido.errors import ProtocolError
+
+
+class TestAsyncClientInit:
+    """Tests for AsyncClient initialization."""
+
+    @patch('gakido.aio.get_profile')
+    def test_default_init(self, mock_get_profile):
+        """Test AsyncClient initialization with defaults."""
+        mock_get_profile.return_value = {"headers": {"default": []}}
+        client = AsyncClient()
+
+        mock_get_profile.assert_called_with("chrome_120")
+        assert client.timeout == 10.0
+        assert client.verify is True
+        assert client.auto_decompress is True
+        assert client.http3_enabled is False
+
+    @patch('gakido.aio.get_profile')
+    def test_custom_impersonate(self, mock_get_profile):
+        """Test AsyncClient with custom impersonate profile."""
+        mock_get_profile.return_value = {"headers": {"default": []}}
+        AsyncClient(impersonate="firefox_133")
+        mock_get_profile.assert_called_with("firefox_133")
+
+    @patch('gakido.aio.get_profile')
+    def test_force_http1_modifies_alpn(self, mock_get_profile):
+        """Test force_http1=True modifies ALPN."""
+        mock_get_profile.return_value = {"headers": {"default": []}}
+        client = AsyncClient(force_http1=True)
+
+        assert client.profile["tls"]["alpn"] == ["http/1.1"]
+
+    @patch('gakido.aio.get_profile')
+    def test_http3_enabled_when_available(self, mock_get_profile):
+        """Test http3=True with available aioquic."""
+        mock_get_profile.return_value = {"headers": {"default": []}}
+        with patch('gakido.aio.is_http3_available', return_value=True):
+            client = AsyncClient(http3=True)
+            assert client.http3_enabled is True
+
+    @patch('gakido.aio.get_profile')
+    def test_http3_disabled_when_unavailable(self, mock_get_profile):
+        """Test http3=True with unavailable aioquic."""
+        mock_get_profile.return_value = {"headers": {"default": []}}
+        with patch('gakido.aio.is_http3_available', return_value=False):
+            client = AsyncClient(http3=True)
+            assert client.http3_enabled is False
+
+    @patch('gakido.aio.get_profile')
+    def test_http3_fallback_default(self, mock_get_profile):
+        """Test http3_fallback defaults to True."""
+        mock_get_profile.return_value = {"headers": {"default": []}}
+        client = AsyncClient()
+        assert client.http3_fallback is True
+
+    @patch('gakido.aio.get_profile')
+    def test_auto_decompress_false(self, mock_get_profile):
+        """Test auto_decompress=False."""
+        mock_get_profile.return_value = {"headers": {"default": []}}
+        client = AsyncClient(auto_decompress=False)
+        assert client.auto_decompress is False
+
+    @patch('gakido.aio.get_profile')
+    def test_proxy_pool_stored(self, mock_get_profile):
+        """Test proxy_pool is stored."""
+        mock_get_profile.return_value = {"headers": {"default": []}}
+        client = AsyncClient(proxy_pool=["http://proxy:8080"])
+        assert client.proxy_pool == ["http://proxy:8080"]
+
+    @patch('gakido.aio.get_profile')
+    def test_ja3_overrides_applied(self, mock_get_profile):
+        """Test ja3 overrides are applied."""
+        mock_get_profile.return_value = {"headers": {"default": []}, "tls": {}}
+        client = AsyncClient(ja3={"ciphers": "custom"})
+        assert client.profile["tls"]["ciphers"] == "custom"
+
+    @patch('gakido.aio.get_profile')
+    def test_tls_configuration_options_applied(self, mock_get_profile):
+        """Test tls_configuration_options are applied."""
+        mock_get_profile.return_value = {"headers": {"default": []}, "tls": {}}
+        client = AsyncClient(tls_configuration_options={"curves": ["X25519"]})
+        # apply_tls_configuration_options should be called
+
+
+class TestAsyncClientRequest:
+    """Tests for AsyncClient.request method."""
+
+    @pytest.mark.asyncio
+    @patch('gakido.aio.get_profile')
+    @patch('gakido.aio.asyncio.open_connection')
+    @patch('gakido.aio.asyncio.wait_for')
+    async def test_request_http11(self, mock_wait_for, mock_open_conn, mock_get_profile):
+        """Test HTTP/1.1 request."""
+        mock_get_profile.return_value = {
+            "headers": {"default": [], "order": []},
+            "tls": {},
+        }
+
+        # Mock reader/writer
+        mock_reader = AsyncMock()
+        mock_writer = MagicMock()
+        mock_writer.close = MagicMock()
+        mock_writer.wait_closed = AsyncMock()
+        mock_writer.drain = AsyncMock()
+        mock_writer.writelines = MagicMock()
+        mock_writer.get_extra_info = MagicMock(return_value=None)
+        mock_wait_for.return_value = (mock_reader, mock_writer)
+
+        # Mock response
+        mock_reader.readline = AsyncMock(side_effect=[
+            b"HTTP/1.1 200 OK\r\n",
+            b"Content-Length: 5\r\n",
+            b"\r\n",
+        ])
+        mock_reader.readexactly = AsyncMock(return_value=b"hello")
+
+        client = AsyncClient()
+        response = await client.request("GET", "http://example.com/path")
+
+        assert response.status_code == 200
+        assert response.content == b"hello"
+
+    @pytest.mark.asyncio
+    @patch('gakido.aio.get_profile')
+    @patch('gakido.aio.asyncio.open_connection')
+    @patch('gakido.aio.asyncio.wait_for')
+    async def test_request_with_data_dict(self, mock_wait_for, mock_open_conn, mock_get_profile):
+        """Test request with dict data is form-encoded."""
+        mock_get_profile.return_value = {
+            "headers": {"default": [], "order": []},
+            "tls": {},
+        }
+
+        mock_reader = AsyncMock()
+        mock_writer = MagicMock()
+        mock_writer.close = MagicMock()
+        mock_writer.wait_closed = AsyncMock()
+        mock_writer.drain = AsyncMock()
+        mock_writer.writelines = MagicMock()
+        mock_writer.get_extra_info = MagicMock(return_value=None)
+        mock_wait_for.return_value = (mock_reader, mock_writer)
+
+        mock_reader.readline = AsyncMock(side_effect=[
+            b"HTTP/1.1 200 OK\r\n",
+            b"Content-Length: 0\r\n",
+            b"\r\n",
+        ])
+        mock_reader.readexactly = AsyncMock(return_value=b"")
+
+        client = AsyncClient()
+        await client.request("POST", "http://example.com", data={"key": "value"})
+
+        # Check writelines was called with form-encoded body
+        call_args = mock_writer.writelines.call_args[0][0]
+        request_str = b"".join(call_args).decode()
+        assert "key=value" in request_str
+
+    @pytest.mark.asyncio
+    @patch('gakido.aio.get_profile')
+    @patch('gakido.aio.asyncio.open_connection')
+    @patch('gakido.aio.asyncio.wait_for')
+    async def test_request_with_string_data(self, mock_wait_for, mock_open_conn, mock_get_profile):
+        """Test request with string data."""
+        mock_get_profile.return_value = {
+            "headers": {"default": [], "order": []},
+            "tls": {},
+        }
+
+        mock_reader = AsyncMock()
+        mock_writer = MagicMock()
+        mock_writer.close = MagicMock()
+        mock_writer.wait_closed = AsyncMock()
+        mock_writer.drain = AsyncMock()
+        mock_writer.writelines = MagicMock()
+        mock_writer.get_extra_info = MagicMock(return_value=None)
+        mock_wait_for.return_value = (mock_reader, mock_writer)
+
+        mock_reader.readline = AsyncMock(side_effect=[
+            b"HTTP/1.1 200 OK\r\n",
+            b"\r\n",
+        ])
+        mock_reader.read = AsyncMock(return_value=b"")
+
+        client = AsyncClient()
+        await client.request("POST", "http://example.com", data="string data")
+
+        # Verify data was sent
+        mock_writer.writelines.assert_called()
+
+    @pytest.mark.asyncio
+    @patch('gakido.aio.get_profile')
+    @patch('gakido.aio.asyncio.open_connection')
+    @patch('gakido.aio.asyncio.wait_for')
+    async def test_request_with_bytes_data(self, mock_wait_for, mock_open_conn, mock_get_profile):
+        """Test request with bytes data."""
+        mock_get_profile.return_value = {
+            "headers": {"default": [], "order": []},
+            "tls": {},
+        }
+
+        mock_reader = AsyncMock()
+        mock_writer = MagicMock()
+        mock_writer.close = MagicMock()
+        mock_writer.wait_closed = AsyncMock()
+        mock_writer.drain = AsyncMock()
+        mock_writer.writelines = MagicMock()
+        mock_writer.get_extra_info = MagicMock(return_value=None)
+        mock_wait_for.return_value = (mock_reader, mock_writer)
+
+        mock_reader.readline = AsyncMock(side_effect=[
+            b"HTTP/1.1 200 OK\r\n",
+            b"\r\n",
+        ])
+        mock_reader.read = AsyncMock(return_value=b"")
+
+        client = AsyncClient()
+        await client.request("POST", "http://example.com", data=b"bytes data")
+
+        mock_writer.writelines.assert_called()
+
+    @pytest.mark.asyncio
+    @patch('gakido.aio.get_profile')
+    async def test_request_invalid_data_type_raises(self, mock_get_profile):
+        """Test request with invalid data type raises TypeError."""
+        mock_get_profile.return_value = {
+            "headers": {"default": [], "order": []},
+            "tls": {},
+        }
+
+        client = AsyncClient()
+        with pytest.raises(TypeError, match="Unsupported data type"):
+            await client.request("POST", "http://example.com", data=12345)
+
+    @pytest.mark.asyncio
+    @patch('gakido.aio.get_profile')
+    @patch('gakido.aio.asyncio.open_connection')
+    @patch('gakido.aio.asyncio.wait_for')
+    async def test_request_chunked_response(self, mock_wait_for, mock_open_conn, mock_get_profile):
+        """Test handling chunked transfer encoding."""
+        mock_get_profile.return_value = {
+            "headers": {"default": [], "order": []},
+            "tls": {},
+        }
+
+        mock_reader = AsyncMock()
+        mock_writer = MagicMock()
+        mock_writer.close = MagicMock()
+        mock_writer.wait_closed = AsyncMock()
+        mock_writer.drain = AsyncMock()
+        mock_writer.writelines = MagicMock()
+        mock_writer.get_extra_info = MagicMock(return_value=None)
+        mock_wait_for.return_value = (mock_reader, mock_writer)
+
+        mock_reader.readline = AsyncMock(side_effect=[
+            b"HTTP/1.1 200 OK\r\n",
+            b"Transfer-Encoding: chunked\r\n",
+            b"\r\n",
+            b"5\r\n",  # chunk size
+            b"0\r\n",  # end chunk
+            b"\r\n",   # final CRLF after 0 chunk
+        ])
+        mock_reader.readexactly = AsyncMock(side_effect=[
+            b"hello",  # chunk data
+            b"\r\n",   # chunk trailer
+        ])
+
+        client = AsyncClient()
+        response = await client.request("GET", "http://example.com")
+
+        assert response.content == b"hello"
+
+    @pytest.mark.asyncio
+    @patch('gakido.aio.get_profile')
+    @patch('gakido.aio.asyncio.open_connection')
+    @patch('gakido.aio.asyncio.wait_for')
+    async def test_request_empty_response_raises(self, mock_wait_for, mock_open_conn, mock_get_profile):
+        """Test empty response raises ProtocolError."""
+        mock_get_profile.return_value = {
+            "headers": {"default": [], "order": []},
+            "tls": {},
+        }
+
+        mock_reader = AsyncMock()
+        mock_writer = MagicMock()
+        mock_writer.close = MagicMock()
+        mock_writer.wait_closed = AsyncMock()
+        mock_writer.drain = AsyncMock()
+        mock_writer.writelines = MagicMock()
+        mock_writer.get_extra_info = MagicMock(return_value=None)
+        mock_wait_for.return_value = (mock_reader, mock_writer)
+
+        mock_reader.readline = AsyncMock(return_value=b"")
+
+        client = AsyncClient()
+        with pytest.raises(ProtocolError, match="Empty response"):
+            await client.request("GET", "http://example.com")
+
+    @pytest.mark.asyncio
+    @patch('gakido.aio.get_profile')
+    @patch('gakido.aio.asyncio.open_connection')
+    @patch('gakido.aio.asyncio.wait_for')
+    async def test_request_malformed_status_raises(self, mock_wait_for, mock_open_conn, mock_get_profile):
+        """Test malformed status line raises ProtocolError."""
+        mock_get_profile.return_value = {
+            "headers": {"default": [], "order": []},
+            "tls": {},
+        }
+
+        mock_reader = AsyncMock()
+        mock_writer = MagicMock()
+        mock_writer.close = MagicMock()
+        mock_writer.wait_closed = AsyncMock()
+        mock_writer.drain = AsyncMock()
+        mock_writer.writelines = MagicMock()
+        mock_writer.get_extra_info = MagicMock(return_value=None)
+        mock_wait_for.return_value = (mock_reader, mock_writer)
+
+        mock_reader.readline = AsyncMock(return_value=b"INVALID\r\n")
+
+        client = AsyncClient()
+        with pytest.raises(ProtocolError, match="Malformed status line"):
+            await client.request("GET", "http://example.com")
+
+    @pytest.mark.asyncio
+    @patch('gakido.aio.get_profile')
+    @patch('gakido.aio.asyncio.open_connection')
+    @patch('gakido.aio.asyncio.wait_for')
+    async def test_request_malformed_header_raises(self, mock_wait_for, mock_open_conn, mock_get_profile):
+        """Test malformed header line raises ProtocolError."""
+        mock_get_profile.return_value = {
+            "headers": {"default": [], "order": []},
+            "tls": {},
+        }
+
+        mock_reader = AsyncMock()
+        mock_writer = MagicMock()
+        mock_writer.close = MagicMock()
+        mock_writer.wait_closed = AsyncMock()
+        mock_writer.drain = AsyncMock()
+        mock_writer.writelines = MagicMock()
+        mock_writer.get_extra_info = MagicMock(return_value=None)
+        mock_wait_for.return_value = (mock_reader, mock_writer)
+
+        mock_reader.readline = AsyncMock(side_effect=[
+            b"HTTP/1.1 200 OK\r\n",
+            b"InvalidHeaderWithoutColon\r\n",
+        ])
+
+        client = AsyncClient()
+        with pytest.raises(ProtocolError, match="Malformed header"):
+            await client.request("GET", "http://example.com")
+
+    @pytest.mark.asyncio
+    @patch('gakido.aio.get_profile')
+    @patch('gakido.aio.build_multipart')
+    @patch('gakido.aio.asyncio.open_connection')
+    @patch('gakido.aio.asyncio.wait_for')
+    async def test_request_with_files(self, mock_wait_for, mock_open_conn, mock_build_multipart, mock_get_profile):
+        """Test request with files uses multipart."""
+        mock_get_profile.return_value = {
+            "headers": {"default": [], "order": []},
+            "tls": {},
+        }
+        mock_build_multipart.return_value = ("multipart/form-data; boundary=xxx", b"multipart body")
+
+        mock_reader = AsyncMock()
+        mock_writer = MagicMock()
+        mock_writer.close = MagicMock()
+        mock_writer.wait_closed = AsyncMock()
+        mock_writer.drain = AsyncMock()
+        mock_writer.writelines = MagicMock()
+        mock_writer.get_extra_info = MagicMock(return_value=None)
+        mock_wait_for.return_value = (mock_reader, mock_writer)
+
+        mock_reader.readline = AsyncMock(side_effect=[
+            b"HTTP/1.1 200 OK\r\n",
+            b"\r\n",
+        ])
+        mock_reader.read = AsyncMock(return_value=b"")
+
+        client = AsyncClient()
+        await client.request("POST", "http://example.com", files={"file": b"content"})
+
+        mock_build_multipart.assert_called()
+
+
+class TestAsyncClientMethods:
+    """Tests for AsyncClient convenience methods."""
+
+    @pytest.mark.asyncio
+    @patch('gakido.aio.get_profile')
+    async def test_close_clears_h3_protocols(self, mock_get_profile):
+        """Test close() clears HTTP/3 protocols cache."""
+        mock_get_profile.return_value = {"headers": {"default": []}}
+        client = AsyncClient()
+        client._h3_protocols["test"] = MagicMock()
+        client._h3_protocols["test"].close = AsyncMock()
+
+        await client.close()
+
+        assert len(client._h3_protocols) == 0
+        assert len(client._h3_failed_hosts) == 0
+
+    @pytest.mark.asyncio
+    @patch('gakido.aio.get_profile')
+    async def test_context_manager(self, mock_get_profile):
+        """Test async context manager."""
+        mock_get_profile.return_value = {"headers": {"default": []}}
+
+        async with AsyncClient() as client:
+            assert isinstance(client, AsyncClient)
+
+    @pytest.mark.asyncio
+    @patch('gakido.aio.get_profile')
+    @patch('gakido.aio.asyncio.open_connection')
+    @patch('gakido.aio.asyncio.wait_for')
+    async def test_get_method(self, mock_wait_for, mock_open_conn, mock_get_profile):
+        """Test get() convenience method."""
+        mock_get_profile.return_value = {
+            "headers": {"default": [], "order": []},
+            "tls": {},
+        }
+
+        mock_reader = AsyncMock()
+        mock_writer = MagicMock()
+        mock_writer.close = MagicMock()
+        mock_writer.wait_closed = AsyncMock()
+        mock_writer.drain = AsyncMock()
+        mock_writer.writelines = MagicMock()
+        mock_writer.get_extra_info = MagicMock(return_value=None)
+        mock_wait_for.return_value = (mock_reader, mock_writer)
+
+        mock_reader.readline = AsyncMock(side_effect=[
+            b"HTTP/1.1 200 OK\r\n",
+            b"\r\n",
+        ])
+        mock_reader.read = AsyncMock(return_value=b"")
+
+        client = AsyncClient()
+        response = await client.get("http://example.com")
+
+        assert response.status_code == 200
+
+    @pytest.mark.asyncio
+    @patch('gakido.aio.get_profile')
+    @patch('gakido.aio.asyncio.open_connection')
+    @patch('gakido.aio.asyncio.wait_for')
+    async def test_post_method(self, mock_wait_for, mock_open_conn, mock_get_profile):
+        """Test post() convenience method."""
+        mock_get_profile.return_value = {
+            "headers": {"default": [], "order": []},
+            "tls": {},
+        }
+
+        mock_reader = AsyncMock()
+        mock_writer = MagicMock()
+        mock_writer.close = MagicMock()
+        mock_writer.wait_closed = AsyncMock()
+        mock_writer.drain = AsyncMock()
+        mock_writer.writelines = MagicMock()
+        mock_writer.get_extra_info = MagicMock(return_value=None)
+        mock_wait_for.return_value = (mock_reader, mock_writer)
+
+        mock_reader.readline = AsyncMock(side_effect=[
+            b"HTTP/1.1 201 Created\r\n",
+            b"\r\n",
+        ])
+        mock_reader.read = AsyncMock(return_value=b"")
+
+        client = AsyncClient()
+        response = await client.post("http://example.com", data={"key": "value"})
+
+        assert response.status_code == 201
+
+
+class TestAsyncClientProxy:
+    """Tests for AsyncClient proxy handling."""
+
+    @pytest.mark.asyncio
+    @patch('gakido.aio.get_profile')
+    @patch('gakido.aio.asyncio.open_connection')
+    async def test_invalid_proxy_scheme_raises(self, mock_open_conn, mock_get_profile):
+        """Test non-http proxy raises ValueError."""
+        mock_get_profile.return_value = {
+            "headers": {"default": [], "order": []},
+            "tls": {},
+        }
+
+        client = AsyncClient()
+        with pytest.raises(ValueError, match="Only http proxy"):
+            await client.request("GET", "http://example.com", proxy="socks5://proxy:1080")
+
+    @pytest.mark.asyncio
+    @patch('gakido.aio.get_profile')
+    @patch('gakido.aio.asyncio.open_connection')
+    @patch('gakido.aio.asyncio.wait_for')
+    async def test_proxy_uses_absolute_url(self, mock_wait_for, mock_open_conn, mock_get_profile):
+        """Test proxy request uses absolute URL form."""
+        mock_get_profile.return_value = {
+            "headers": {"default": [], "order": []},
+            "tls": {},
+        }
+
+        mock_reader = AsyncMock()
+        mock_writer = MagicMock()
+        mock_writer.close = MagicMock()
+        mock_writer.wait_closed = AsyncMock()
+        mock_writer.drain = AsyncMock()
+        mock_writer.writelines = MagicMock()
+        mock_writer.get_extra_info = MagicMock(return_value=None)
+        mock_wait_for.return_value = (mock_reader, mock_writer)
+
+        mock_reader.readline = AsyncMock(side_effect=[
+            b"HTTP/1.1 200 OK\r\n",
+            b"\r\n",
+        ])
+        mock_reader.read = AsyncMock(return_value=b"")
+
+        client = AsyncClient()
+        await client.request("GET", "http://example.com/path", proxy="http://proxy:8080")
+
+        # Check absolute URL in request line
+        call_args = mock_writer.writelines.call_args[0][0]
+        request_line = call_args[0].decode()
+        assert "http://example.com/path" in request_line
+
+
+class TestAsyncClientHTTPS:
+    """Tests for AsyncClient HTTPS handling."""
+
+    @pytest.mark.asyncio
+    @patch('gakido.aio.get_profile')
+    @patch('gakido.aio.ssl.create_default_context')
+    @patch('gakido.aio.asyncio.open_connection')
+    @patch('gakido.aio.asyncio.wait_for')
+    async def test_https_creates_ssl_context(self, mock_wait_for, mock_open_conn, mock_ssl_ctx, mock_get_profile):
+        """Test HTTPS creates SSL context."""
+        mock_get_profile.return_value = {
+            "headers": {"default": [], "order": []},
+            "tls": {"ciphers": "TLS_AES_128_GCM_SHA256"},
+        }
+        mock_ctx = MagicMock()
+        mock_ssl_ctx.return_value = mock_ctx
+
+        mock_reader = AsyncMock()
+        mock_writer = MagicMock()
+        mock_writer.close = MagicMock()
+        mock_writer.wait_closed = AsyncMock()
+        mock_writer.drain = AsyncMock()
+        mock_writer.writelines = MagicMock()
+        mock_writer.get_extra_info = MagicMock(return_value=None)
+        mock_wait_for.return_value = (mock_reader, mock_writer)
+
+        mock_reader.readline = AsyncMock(side_effect=[
+            b"HTTP/1.1 200 OK\r\n",
+            b"\r\n",
+        ])
+        mock_reader.read = AsyncMock(return_value=b"")
+
+        client = AsyncClient()
+        await client.request("GET", "https://example.com")
+
+        mock_ssl_ctx.assert_called()
+
+    @pytest.mark.asyncio
+    @patch('gakido.aio.get_profile')
+    @patch('gakido.aio.ssl.create_default_context')
+    @patch('gakido.aio.asyncio.open_connection')
+    @patch('gakido.aio.asyncio.wait_for')
+    async def test_https_verify_false(self, mock_wait_for, mock_open_conn, mock_ssl_ctx, mock_get_profile):
+        """Test HTTPS with verify=False."""
+        mock_get_profile.return_value = {
+            "headers": {"default": [], "order": []},
+            "tls": {},
+        }
+        mock_ctx = MagicMock()
+        mock_ssl_ctx.return_value = mock_ctx
+
+        mock_reader = AsyncMock()
+        mock_writer = MagicMock()
+        mock_writer.close = MagicMock()
+        mock_writer.wait_closed = AsyncMock()
+        mock_writer.drain = AsyncMock()
+        mock_writer.writelines = MagicMock()
+        mock_writer.get_extra_info = MagicMock(return_value=None)
+        mock_wait_for.return_value = (mock_reader, mock_writer)
+
+        mock_reader.readline = AsyncMock(side_effect=[
+            b"HTTP/1.1 200 OK\r\n",
+            b"\r\n",
+        ])
+        mock_reader.read = AsyncMock(return_value=b"")
+
+        client = AsyncClient(verify=False)
+        await client.request("GET", "https://example.com")
+
+        assert mock_ctx.check_hostname is False
+        assert mock_ctx.verify_mode == ssl.CERT_NONE
+
+
+class TestAsyncClientH3FailedHosts:
+    """Tests for HTTP/3 failed hosts tracking."""
+
+    @patch('gakido.aio.get_profile')
+    def test_h3_failed_hosts_initially_empty(self, mock_get_profile):
+        """Test _h3_failed_hosts starts empty."""
+        mock_get_profile.return_value = {"headers": {"default": []}}
+        client = AsyncClient()
+        assert len(client._h3_failed_hosts) == 0
+
+    @pytest.mark.asyncio
+    @patch('gakido.aio.get_profile')
+    async def test_close_clears_failed_hosts(self, mock_get_profile):
+        """Test close() clears failed hosts set."""
+        mock_get_profile.return_value = {"headers": {"default": []}}
+        client = AsyncClient()
+        client._h3_failed_hosts.add("example.com")
+
+        await client.close()
+
+        assert len(client._h3_failed_hosts) == 0
+
+
+class TestAsyncClientHTTP2:
+    """Tests for AsyncClient HTTP/2 handling."""
+
+    @pytest.mark.asyncio
+    @patch('gakido.aio.get_profile')
+    async def test_h2_alpn_set_when_force_http1_false(self, mock_get_profile):
+        """Test HTTP/2 ALPN is set when force_http1=False."""
+        mock_get_profile.return_value = {
+            "headers": {"default": [], "order": []},
+            "tls": {"alpn": ["h2", "http/1.1"]},
+            "http2": {"alpn": ["h2", "http/1.1"]},
+        }
+
+        client = AsyncClient(force_http1=False)
+
+        # When force_http1=False, ALPN should not be overwritten to http/1.1 only
+        assert client.profile["tls"]["alpn"] == ["h2", "http/1.1"]
+
+
+class TestAsyncClientDecompression:
+    """Tests for AsyncClient auto decompression."""
+
+    @pytest.mark.asyncio
+    @patch('gakido.aio.decode_body')
+    @patch('gakido.aio.get_profile')
+    @patch('gakido.aio.asyncio.open_connection')
+    @patch('gakido.aio.asyncio.wait_for')
+    async def test_auto_decompress_enabled(self, mock_wait_for, mock_open_conn, mock_get_profile, mock_decode):
+        """Test auto decompression when enabled."""
+        mock_get_profile.return_value = {
+            "headers": {"default": [], "order": []},
+            "tls": {},
+        }
+        mock_decode.return_value = b"decompressed"
+
+        mock_reader = AsyncMock()
+        mock_writer = MagicMock()
+        mock_writer.close = MagicMock()
+        mock_writer.wait_closed = AsyncMock()
+        mock_writer.drain = AsyncMock()
+        mock_writer.writelines = MagicMock()
+        mock_writer.get_extra_info = MagicMock(return_value=None)
+        mock_wait_for.return_value = (mock_reader, mock_writer)
+
+        mock_reader.readline = AsyncMock(side_effect=[
+            b"HTTP/1.1 200 OK\r\n",
+            b"Content-Encoding: gzip\r\n",
+            b"Content-Length: 10\r\n",
+            b"\r\n",
+        ])
+        mock_reader.readexactly = AsyncMock(return_value=b"compressed")
+
+        client = AsyncClient(auto_decompress=True)
+        response = await client.request("GET", "http://example.com")
+
+        mock_decode.assert_called_with(b"compressed", "gzip")
+        assert response.content == b"decompressed"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,497 @@
+"""Tests for gakido.client module."""
+
+import pytest
+from unittest.mock import Mock, patch, MagicMock
+from gakido.client import Client
+from gakido.models import Response
+
+
+class TestClientInit:
+    """Tests for Client initialization."""
+
+    @patch('gakido.client.ConnectionPool')
+    @patch('gakido.client.get_profile')
+    def test_default_init(self, mock_get_profile, mock_pool):
+        """Test Client initialization with defaults."""
+        mock_get_profile.return_value = {"headers": {"default": []}}
+        client = Client()
+
+        mock_get_profile.assert_called_with("chrome_120")
+        assert client.timeout == 10.0
+        assert client.verify is True
+        assert client.auto_decompress is True
+
+    @patch('gakido.client.ConnectionPool')
+    @patch('gakido.client.get_profile')
+    def test_custom_impersonate(self, mock_get_profile, mock_pool):
+        """Test Client with custom impersonate profile."""
+        mock_get_profile.return_value = {"headers": {"default": []}}
+        Client(impersonate="firefox_133")
+        mock_get_profile.assert_called_with("firefox_133")
+
+    @patch('gakido.client.ConnectionPool')
+    @patch('gakido.client.get_profile')
+    def test_force_http1_modifies_alpn(self, mock_get_profile, mock_pool):
+        """Test force_http1=True modifies ALPN."""
+        mock_get_profile.return_value = {"headers": {"default": []}}
+        client = Client(force_http1=True)
+
+        assert client.profile["tls"]["alpn"] == ["http/1.1"]
+
+    @patch('gakido.client.ConnectionPool')
+    @patch('gakido.client.get_profile')
+    def test_auto_decompress_false(self, mock_get_profile, mock_pool):
+        """Test auto_decompress=False."""
+        mock_get_profile.return_value = {"headers": {"default": []}}
+        client = Client(auto_decompress=False)
+        assert client.auto_decompress is False
+
+    @patch('gakido.client.ConnectionPool')
+    @patch('gakido.client.get_profile')
+    def test_proxies_stored(self, mock_get_profile, mock_pool):
+        """Test proxies are stored."""
+        mock_get_profile.return_value = {"headers": {"default": []}}
+        client = Client(proxies=["http://proxy:8080"])
+        assert client.proxies == ["http://proxy:8080"]
+
+    @patch('gakido.client.ConnectionPool')
+    @patch('gakido.client.get_profile')
+    def test_ja3_applied(self, mock_get_profile, mock_pool):
+        """Test ja3 overrides are applied."""
+        mock_get_profile.return_value = {"headers": {"default": []}, "tls": {}}
+        client = Client(ja3={"alpn": ["h2"]})
+        assert client.profile["tls"]["alpn"] == ["h2"]
+
+    @patch('gakido.client.gakido_core', None)
+    @patch('gakido.client.ConnectionPool')
+    @patch('gakido.client.get_profile')
+    def test_use_native_false_when_no_core(self, mock_get_profile, mock_pool):
+        """Test use_native is False when gakido_core is None."""
+        mock_get_profile.return_value = {"headers": {"default": []}}
+        client = Client(use_native=True)
+        assert client.use_native is False
+
+    @patch('gakido.client.ConnectionPool')
+    @patch('gakido.client.get_profile')
+    def test_max_per_host_passed_to_pool(self, mock_get_profile, mock_pool):
+        """Test max_per_host is passed to ConnectionPool."""
+        mock_get_profile.return_value = {"headers": {"default": []}}
+        Client(max_per_host=8)
+
+        mock_pool.assert_called_once()
+        call_kwargs = mock_pool.call_args[1]
+        assert call_kwargs["max_per_host"] == 8
+
+
+class TestClientRequest:
+    """Tests for Client.request method."""
+
+    @patch('gakido.client.ConnectionPool')
+    @patch('gakido.client.get_profile')
+    def test_request_returns_response(self, mock_get_profile, mock_pool):
+        """Test request returns Response object."""
+        mock_get_profile.return_value = {
+            "headers": {"default": [], "order": []},
+            "tls": {},
+        }
+        mock_conn = MagicMock()
+        mock_response = Response(200, "OK", "1.1", [], b"body")
+        mock_conn.request.return_value = mock_response
+        mock_conn.closed = False
+        mock_pool.return_value.acquire.return_value = mock_conn
+
+        # Use https to bypass native code path, or use_native=False
+        client = Client(use_native=False)
+        resp = client.request("GET", "https://example.com/path")
+
+        assert resp.status_code == 200
+
+    @patch('gakido.client.ConnectionPool')
+    @patch('gakido.client.get_profile')
+    def test_request_with_data_dict(self, mock_get_profile, mock_pool):
+        """Test request with dict data is form-encoded."""
+        mock_get_profile.return_value = {
+            "headers": {"default": [], "order": []},
+            "tls": {},
+        }
+        mock_conn = MagicMock()
+        mock_response = Response(200, "OK", "1.1", [], b"")
+        mock_conn.request.return_value = mock_response
+        mock_conn.closed = False
+        mock_pool.return_value.acquire.return_value = mock_conn
+
+        client = Client(use_native=False)
+        client.request("POST", "https://example.com", data={"key": "value"})
+
+        # Verify body was form-encoded
+        call_args = mock_conn.request.call_args
+        body = call_args[1].get("body") or call_args[0][3]
+        assert b"key=value" in body if body else True
+
+    @patch('gakido.client.ConnectionPool')
+    @patch('gakido.client.get_profile')
+    def test_request_with_bytes_data(self, mock_get_profile, mock_pool):
+        """Test request with bytes data."""
+        mock_get_profile.return_value = {
+            "headers": {"default": [], "order": []},
+            "tls": {},
+        }
+        mock_conn = MagicMock()
+        mock_response = Response(200, "OK", "1.1", [], b"")
+        mock_conn.request.return_value = mock_response
+        mock_conn.closed = False
+        mock_pool.return_value.acquire.return_value = mock_conn
+
+        client = Client(use_native=False)
+        client.request("POST", "https://example.com", data=b"raw bytes")
+
+        mock_conn.request.assert_called()
+
+    @patch('gakido.client.ConnectionPool')
+    @patch('gakido.client.get_profile')
+    def test_request_with_string_data(self, mock_get_profile, mock_pool):
+        """Test request with string data."""
+        mock_get_profile.return_value = {
+            "headers": {"default": [], "order": []},
+            "tls": {},
+        }
+        mock_conn = MagicMock()
+        mock_response = Response(200, "OK", "1.1", [], b"")
+        mock_conn.request.return_value = mock_response
+        mock_conn.closed = False
+        mock_pool.return_value.acquire.return_value = mock_conn
+
+        client = Client(use_native=False)
+        client.request("POST", "https://example.com", data="string data")
+
+        mock_conn.request.assert_called()
+
+    @patch('gakido.client.ConnectionPool')
+    @patch('gakido.client.get_profile')
+    def test_request_invalid_data_type_raises(self, mock_get_profile, mock_pool):
+        """Test request with invalid data type raises TypeError."""
+        mock_get_profile.return_value = {
+            "headers": {"default": [], "order": []},
+            "tls": {},
+        }
+        mock_pool.return_value.acquire.return_value = MagicMock()
+
+        client = Client(use_native=False)
+        with pytest.raises(TypeError, match="Unsupported data type"):
+            client.request("POST", "https://example.com", data=12345)
+
+    @patch('gakido.client.build_multipart')
+    @patch('gakido.client.ConnectionPool')
+    @patch('gakido.client.get_profile')
+    def test_request_with_files(self, mock_get_profile, mock_pool, mock_build_multipart):
+        """Test request with files uses multipart."""
+        mock_get_profile.return_value = {
+            "headers": {"default": [], "order": []},
+            "tls": {},
+        }
+        mock_build_multipart.return_value = ("multipart/form-data; boundary=xxx", b"multipart body")
+        mock_conn = MagicMock()
+        mock_response = Response(200, "OK", "1.1", [], b"")
+        mock_conn.request.return_value = mock_response
+        mock_conn.closed = False
+        mock_pool.return_value.acquire.return_value = mock_conn
+
+        client = Client(use_native=False)
+        client.request("POST", "https://example.com", files={"file": b"content"})
+
+        mock_build_multipart.assert_called()
+
+    @patch('gakido.client.ConnectionPool')
+    @patch('gakido.client.get_profile')
+    def test_request_post_adds_content_length_zero(self, mock_get_profile, mock_pool):
+        """Test POST without body adds Content-Length: 0."""
+        mock_get_profile.return_value = {
+            "headers": {"default": [], "order": []},
+            "tls": {},
+        }
+        mock_conn = MagicMock()
+        mock_response = Response(200, "OK", "1.1", [], b"")
+        mock_conn.request.return_value = mock_response
+        mock_conn.closed = False
+        mock_pool.return_value.acquire.return_value = mock_conn
+
+        client = Client(use_native=False)
+        client.request("POST", "https://example.com")
+
+        call_args = mock_conn.request.call_args[0]
+        headers = call_args[2]  # Third argument is headers
+        header_dict = {name.lower(): value for name, value in headers}
+        assert header_dict.get("content-length") == "0"
+
+    @patch('gakido.client.ConnectionPool')
+    @patch('gakido.client.get_profile')
+    def test_request_connection_exception_closes_conn(self, mock_get_profile, mock_pool):
+        """Test connection exception closes connection."""
+        mock_get_profile.return_value = {
+            "headers": {"default": [], "order": []},
+            "tls": {},
+        }
+        mock_conn = MagicMock()
+        mock_conn.request.side_effect = Exception("connection error")
+        mock_pool.return_value.acquire.return_value = mock_conn
+
+        client = Client(use_native=False)
+        with pytest.raises(Exception, match="connection error"):
+            client.request("GET", "https://example.com")
+
+        mock_conn.close.assert_called_once()
+
+    @patch('gakido.client.ConnectionPool')
+    @patch('gakido.client.get_profile')
+    def test_request_connection_released_when_not_closed(self, mock_get_profile, mock_pool):
+        """Test connection is released when not closed."""
+        mock_get_profile.return_value = {
+            "headers": {"default": [], "order": []},
+            "tls": {},
+        }
+        mock_conn = MagicMock()
+        mock_response = Response(200, "OK", "1.1", [], b"")
+        mock_conn.request.return_value = mock_response
+        mock_conn.closed = False
+        mock_pool.return_value.acquire.return_value = mock_conn
+
+        client = Client(use_native=False)
+        client.request("GET", "https://example.com")
+
+        mock_pool.return_value.release.assert_called_once_with(mock_conn)
+
+
+class TestClientNativePath:
+    """Tests for Client native code path."""
+
+    @patch('gakido.client.gakido_core')
+    @patch('gakido.client.ConnectionPool')
+    @patch('gakido.client.get_profile')
+    def test_native_path_http(self, mock_get_profile, mock_pool, mock_core):
+        """Test native path is used for HTTP."""
+        mock_get_profile.return_value = {
+            "headers": {"default": [], "order": []},
+            "tls": {},
+        }
+        mock_core.request.return_value = (200, "OK", "1.1", [], b"body")
+        mock_conn = MagicMock()
+        mock_conn.closed = False
+        mock_pool.return_value.acquire.return_value = mock_conn
+
+        client = Client(use_native=True)
+        response = client.request("GET", "http://example.com/path")
+
+        mock_core.request.assert_called_once()
+        assert response.status_code == 200
+
+    @patch('gakido.client.decode_body')
+    @patch('gakido.client.gakido_core')
+    @patch('gakido.client.ConnectionPool')
+    @patch('gakido.client.get_profile')
+    def test_native_path_decompresses(self, mock_get_profile, mock_pool, mock_core, mock_decode):
+        """Test native path decompresses response."""
+        mock_get_profile.return_value = {
+            "headers": {"default": [], "order": []},
+            "tls": {},
+        }
+        mock_core.request.return_value = (
+            200, "OK", "1.1",
+            [("content-encoding", "gzip")],
+            b"compressed"
+        )
+        mock_decode.return_value = b"decompressed"
+        mock_conn = MagicMock()
+        mock_conn.closed = False
+        mock_pool.return_value.acquire.return_value = mock_conn
+
+        client = Client(use_native=True, auto_decompress=True)
+        response = client.request("GET", "http://example.com")
+
+        mock_decode.assert_called_with(b"compressed", "gzip")
+        assert response.content == b"decompressed"
+
+
+class TestClientMethods:
+    """Tests for Client convenience methods."""
+
+    @patch('gakido.client.ConnectionPool')
+    @patch('gakido.client.get_profile')
+    def test_get_method(self, mock_get_profile, mock_pool):
+        """Test get() convenience method."""
+        mock_get_profile.return_value = {
+            "headers": {"default": [], "order": []},
+            "tls": {},
+        }
+        mock_conn = MagicMock()
+        mock_response = Response(200, "OK", "1.1", [], b"")
+        mock_conn.request.return_value = mock_response
+        mock_conn.closed = False
+        mock_pool.return_value.acquire.return_value = mock_conn
+
+        client = Client(use_native=False)
+        client.get("https://example.com")
+
+        mock_conn.request.assert_called()
+        args = mock_conn.request.call_args[0]
+        assert args[0] == "GET"
+
+    @patch('gakido.client.ConnectionPool')
+    @patch('gakido.client.get_profile')
+    def test_post_method(self, mock_get_profile, mock_pool):
+        """Test post() convenience method."""
+        mock_get_profile.return_value = {
+            "headers": {"default": [], "order": []},
+            "tls": {},
+        }
+        mock_conn = MagicMock()
+        mock_response = Response(200, "OK", "1.1", [], b"")
+        mock_conn.request.return_value = mock_response
+        mock_conn.closed = False
+        mock_pool.return_value.acquire.return_value = mock_conn
+
+        client = Client(use_native=False)
+        client.post("https://example.com", data={"key": "value"})
+
+        mock_conn.request.assert_called()
+        args = mock_conn.request.call_args[0]
+        assert args[0] == "POST"
+
+    @patch('gakido.client.ConnectionPool')
+    @patch('gakido.client.get_profile')
+    def test_close_method(self, mock_get_profile, mock_pool):
+        """Test close() closes the pool."""
+        mock_get_profile.return_value = {"headers": {"default": []}, "tls": {}}
+        client = Client()
+        client.close()
+        mock_pool.return_value.close.assert_called_once()
+
+
+class TestClientContextManager:
+    """Tests for Client context manager."""
+
+    @patch('gakido.client.ConnectionPool')
+    @patch('gakido.client.get_profile')
+    def test_context_manager_enter(self, mock_get_profile, mock_pool):
+        """Test context manager __enter__."""
+        mock_get_profile.return_value = {"headers": {"default": []}, "tls": {}}
+        client = Client()
+        result = client.__enter__()
+        assert result is client
+
+    @patch('gakido.client.ConnectionPool')
+    @patch('gakido.client.get_profile')
+    def test_context_manager_exit(self, mock_get_profile, mock_pool):
+        """Test context manager __exit__ closes client."""
+        mock_get_profile.return_value = {"headers": {"default": []}, "tls": {}}
+        with Client() as client:
+            pass
+        mock_pool.return_value.close.assert_called_once()
+
+
+class TestClientProxy:
+    """Tests for Client proxy handling."""
+
+    @patch('gakido.client.ConnectionPool')
+    @patch('gakido.client.get_profile')
+    def test_invalid_proxy_scheme_raises(self, mock_get_profile, mock_pool):
+        """Test non-http proxy raises ValueError."""
+        mock_get_profile.return_value = {
+            "headers": {"default": [], "order": []},
+            "tls": {},
+        }
+        mock_pool.return_value.acquire.return_value = MagicMock()
+
+        client = Client()
+        with pytest.raises(ValueError, match="Only http proxies"):
+            client.request("GET", "http://example.com", proxy="socks5://proxy:1080")
+
+    @patch('gakido.client.ConnectionPool')
+    @patch('gakido.client.get_profile')
+    def test_proxy_uses_absolute_url(self, mock_get_profile, mock_pool):
+        """Test proxy request uses absolute URL form."""
+        mock_get_profile.return_value = {
+            "headers": {"default": [], "order": []},
+            "tls": {},
+        }
+        mock_conn = MagicMock()
+        mock_response = Response(200, "OK", "1.1", [], b"")
+        mock_conn.request.return_value = mock_response
+        mock_conn.closed = False
+        mock_pool.return_value.acquire.return_value = mock_conn
+
+        client = Client(use_native=False)
+        client.request("GET", "http://example.com/path", proxy="http://proxy:8080")
+
+        call_args = mock_conn.request.call_args[0]
+        path = call_args[1]
+        assert path == "http://example.com/path"
+
+    @patch('gakido.client.ConnectionPool')
+    @patch('gakido.client.get_profile')
+    def test_proxy_pool_uses_first_proxy(self, mock_get_profile, mock_pool):
+        """Test proxy pool uses first proxy."""
+        mock_get_profile.return_value = {
+            "headers": {"default": [], "order": []},
+            "tls": {},
+        }
+        mock_conn = MagicMock()
+        mock_response = Response(200, "OK", "1.1", [], b"")
+        mock_conn.request.return_value = mock_response
+        mock_conn.closed = False
+        mock_pool.return_value.acquire.return_value = mock_conn
+
+        client = Client(use_native=False, proxies=["http://proxy1:8080", "http://proxy2:8080"])
+        client.request("GET", "http://example.com")
+
+        # Verify pool was acquired with proxy host/port
+        call_args = mock_pool.return_value.acquire.call_args[0]
+        assert call_args[1] == "proxy1"  # host
+        assert call_args[2] == 8080  # port
+
+
+class TestClientHeaders:
+    """Tests for Client header handling."""
+
+    @patch('gakido.client.ConnectionPool')
+    @patch('gakido.client.get_profile')
+    def test_connection_header_added(self, mock_get_profile, mock_pool):
+        """Test Connection: keep-alive is added by default."""
+        mock_get_profile.return_value = {
+            "headers": {"default": [], "order": []},
+            "tls": {},
+        }
+        mock_conn = MagicMock()
+        mock_response = Response(200, "OK", "1.1", [], b"")
+        mock_conn.request.return_value = mock_response
+        mock_conn.closed = False
+        mock_pool.return_value.acquire.return_value = mock_conn
+
+        client = Client(use_native=False)
+        client.request("GET", "https://example.com")
+
+        call_args = mock_conn.request.call_args[0]
+        headers = call_args[2]
+        header_dict = {name.lower(): value for name, value in headers}
+        assert header_dict.get("connection") == "keep-alive"
+
+    @patch('gakido.client.ConnectionPool')
+    @patch('gakido.client.get_profile')
+    def test_user_headers_merged(self, mock_get_profile, mock_pool):
+        """Test user headers are merged with defaults."""
+        mock_get_profile.return_value = {
+            "headers": {"default": [("User-Agent", "TestAgent")], "order": []},
+            "tls": {},
+        }
+        mock_conn = MagicMock()
+        mock_response = Response(200, "OK", "1.1", [], b"")
+        mock_conn.request.return_value = mock_response
+        mock_conn.closed = False
+        mock_pool.return_value.acquire.return_value = mock_conn
+
+        client = Client(use_native=False)
+        client.request("GET", "https://example.com", headers={"X-Custom": "value"})
+
+        call_args = mock_conn.request.call_args[0]
+        headers = call_args[2]
+        header_dict = {name: value for name, value in headers}
+        assert "X-Custom" in header_dict or "x-custom" in header_dict.keys()

--- a/tests/test_compression.py
+++ b/tests/test_compression.py
@@ -1,0 +1,239 @@
+"""Tests for gakido.compression module."""
+
+import pytest
+import gzip
+import zlib
+import io
+
+from gakido.compression import (
+    decode_body,
+    get_accept_encoding,
+    DEFAULT_ACCEPT_ENCODING,
+    BROTLI_AVAILABLE,
+    _decode_single,
+)
+
+
+class TestDecodeBody:
+    """Tests for decode_body function."""
+
+    def test_decode_empty_body(self):
+        """Test empty body returns unchanged."""
+        result = decode_body(b"", "gzip")
+        assert result == b""
+
+    def test_decode_empty_encoding(self):
+        """Test empty encoding returns body unchanged."""
+        result = decode_body(b"test body", "")
+        assert result == b"test body"
+
+    def test_decode_gzip(self):
+        """Test gzip decompression."""
+        # Create gzip compressed data
+        buf = io.BytesIO()
+        with gzip.GzipFile(fileobj=buf, mode="wb") as f:
+            f.write(b"hello world")
+        compressed = buf.getvalue()
+
+        result = decode_body(compressed, "gzip")
+        assert result == b"hello world"
+
+    def test_decode_deflate_raw(self):
+        """Test raw deflate decompression."""
+        # Create raw deflate compressed data (no zlib header)
+        compress_obj = zlib.compressobj(level=6, method=zlib.DEFLATED, wbits=-zlib.MAX_WBITS)
+        compressed = compress_obj.compress(b"hello world") + compress_obj.flush()
+
+        result = decode_body(compressed, "deflate")
+        assert result == b"hello world"
+
+    def test_decode_deflate_zlib_wrapped(self):
+        """Test zlib-wrapped deflate decompression."""
+        # Create zlib-wrapped compressed data
+        compressed = zlib.compress(b"hello world")
+
+        result = decode_body(compressed, "deflate")
+        assert result == b"hello world"
+
+    @pytest.mark.skipif(not BROTLI_AVAILABLE, reason="brotli not installed")
+    def test_decode_brotli(self):
+        """Test brotli decompression."""
+        import brotli
+        compressed = brotli.compress(b"hello world")
+
+        result = decode_body(compressed, "br")
+        assert result == b"hello world"
+
+    @pytest.mark.skipif(BROTLI_AVAILABLE, reason="brotli is installed")
+    def test_decode_brotli_unavailable(self):
+        """Test br returns unchanged when brotli not available."""
+        result = decode_body(b"fake brotli data", "br")
+        assert result == b"fake brotli data"
+
+    def test_decode_unknown_encoding(self):
+        """Test unknown encoding returns body unchanged."""
+        result = decode_body(b"test data", "unknown-encoding")
+        assert result == b"test data"
+
+    def test_decode_multiple_encodings(self):
+        """Test multiple encodings are decoded in reverse order."""
+        # First compress with gzip
+        buf = io.BytesIO()
+        with gzip.GzipFile(fileobj=buf, mode="wb") as f:
+            f.write(b"hello world")
+        gzipped = buf.getvalue()
+
+        # Per HTTP spec, encodings are applied in order listed and decoded in reverse
+        # So "gzip, deflate" means: server applied gzip first, then deflate
+        # We decode: deflate first, then gzip
+        deflated = zlib.compress(gzipped)
+
+        result = decode_body(deflated, "gzip, deflate")
+        assert result == b"hello world"
+
+    def test_decode_gzip_invalid_data(self):
+        """Test invalid gzip data returns original."""
+        result = decode_body(b"not gzip data", "gzip")
+        assert result == b"not gzip data"
+
+    def test_decode_deflate_invalid_data(self):
+        """Test invalid deflate data returns original."""
+        result = decode_body(b"not deflate data", "deflate")
+        assert result == b"not deflate data"
+
+    @pytest.mark.skipif(not BROTLI_AVAILABLE, reason="brotli not installed")
+    def test_decode_brotli_invalid_data(self):
+        """Test invalid brotli data returns original."""
+        result = decode_body(b"not brotli data", "br")
+        assert result == b"not brotli data"
+
+    def test_decode_case_insensitive(self):
+        """Test encoding is case-insensitive."""
+        buf = io.BytesIO()
+        with gzip.GzipFile(fileobj=buf, mode="wb") as f:
+            f.write(b"hello")
+        compressed = buf.getvalue()
+
+        result = decode_body(compressed, "GZIP")
+        assert result == b"hello"
+
+    def test_decode_whitespace_handling(self):
+        """Test whitespace in encoding is handled."""
+        buf = io.BytesIO()
+        with gzip.GzipFile(fileobj=buf, mode="wb") as f:
+            f.write(b"hello")
+        compressed = buf.getvalue()
+
+        result = decode_body(compressed, "  gzip  ")
+        assert result == b"hello"
+
+
+class TestDecodeSingle:
+    """Tests for _decode_single function."""
+
+    def test_decode_single_gzip(self):
+        """Test single gzip decoding."""
+        buf = io.BytesIO()
+        with gzip.GzipFile(fileobj=buf, mode="wb") as f:
+            f.write(b"test")
+        compressed = buf.getvalue()
+
+        result = _decode_single(compressed, "gzip")
+        assert result == b"test"
+
+    def test_decode_single_deflate(self):
+        """Test single deflate decoding."""
+        compressed = zlib.compress(b"test")
+        result = _decode_single(compressed, "deflate")
+        assert result == b"test"
+
+    def test_decode_single_unknown(self):
+        """Test unknown encoding returns unchanged."""
+        result = _decode_single(b"data", "xyz")
+        assert result == b"data"
+
+
+class TestGetAcceptEncoding:
+    """Tests for get_accept_encoding function."""
+
+    def test_auto_decompress_false(self):
+        """Test auto_decompress=False returns identity."""
+        result = get_accept_encoding({}, auto_decompress=False)
+        assert result == "identity"
+
+    def test_auto_decompress_true_no_profile(self):
+        """Test auto_decompress=True with no profile returns default."""
+        result = get_accept_encoding({}, auto_decompress=True)
+        assert result == DEFAULT_ACCEPT_ENCODING
+
+    def test_profile_with_accept_encoding(self):
+        """Test profile Accept-Encoding is used."""
+        profile = {
+            "headers": {
+                "default": [
+                    ("Accept-Encoding", "gzip, deflate"),
+                ]
+            }
+        }
+        result = get_accept_encoding(profile, auto_decompress=True)
+        assert result == "gzip, deflate"
+
+    def test_profile_without_headers(self):
+        """Test profile without headers returns default."""
+        profile = {"tls": {}}
+        result = get_accept_encoding(profile, auto_decompress=True)
+        assert result == DEFAULT_ACCEPT_ENCODING
+
+    def test_profile_with_other_headers(self):
+        """Test profile with other headers returns default."""
+        profile = {
+            "headers": {
+                "default": [
+                    ("User-Agent", "Test"),
+                ]
+            }
+        }
+        result = get_accept_encoding(profile, auto_decompress=True)
+        assert result == DEFAULT_ACCEPT_ENCODING
+
+    def test_accept_encoding_case_insensitive(self):
+        """Test Accept-Encoding header name is case-insensitive."""
+        profile = {
+            "headers": {
+                "default": [
+                    ("ACCEPT-ENCODING", "gzip"),
+                ]
+            }
+        }
+        result = get_accept_encoding(profile, auto_decompress=True)
+        assert result == "gzip"
+
+
+class TestDefaultAcceptEncoding:
+    """Tests for DEFAULT_ACCEPT_ENCODING constant."""
+
+    def test_contains_gzip(self):
+        """Test default includes gzip."""
+        assert "gzip" in DEFAULT_ACCEPT_ENCODING
+
+    def test_contains_deflate(self):
+        """Test default includes deflate."""
+        assert "deflate" in DEFAULT_ACCEPT_ENCODING
+
+    @pytest.mark.skipif(not BROTLI_AVAILABLE, reason="brotli not installed")
+    def test_contains_br_when_available(self):
+        """Test default includes br when brotli available."""
+        assert "br" in DEFAULT_ACCEPT_ENCODING
+
+    @pytest.mark.skipif(BROTLI_AVAILABLE, reason="brotli is installed")
+    def test_no_br_when_unavailable(self):
+        """Test default does not include br when brotli unavailable."""
+        assert "br" not in DEFAULT_ACCEPT_ENCODING
+
+
+class TestBrotliAvailable:
+    """Tests for BROTLI_AVAILABLE constant."""
+
+    def test_is_boolean(self):
+        """Test BROTLI_AVAILABLE is boolean."""
+        assert isinstance(BROTLI_AVAILABLE, bool)

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,0 +1,672 @@
+"""Tests for gakido.connection module."""
+
+import pytest
+from unittest.mock import Mock, patch, MagicMock, PropertyMock
+import socket
+import ssl
+
+from gakido.connection import Connection
+from gakido.models import Response
+from gakido.errors import ConnectionError, ProtocolError, TLSNegotiationError
+
+
+class TestConnectionInit:
+    """Tests for Connection initialization."""
+
+    def test_init_sets_attributes(self):
+        """Test Connection initializes with correct attributes."""
+        conn = Connection(
+            host="example.com",
+            port=443,
+            scheme="https",
+            profile={"tls": {}},
+            timeout=30.0,
+            verify=False,
+        )
+
+        assert conn.host == "example.com"
+        assert conn.port == 443
+        assert conn.scheme == "https"
+        assert conn.timeout == 30.0
+        assert conn.verify is False
+        assert conn.sock is None
+        assert conn.closed is True
+
+    def test_init_default_values(self):
+        """Test Connection initializes with default timeout and verify."""
+        conn = Connection(
+            host="example.com",
+            port=80,
+            scheme="http",
+            profile={},
+        )
+
+        assert conn.timeout == 10.0
+        assert conn.verify is True
+
+
+class TestConnectionConnect:
+    """Tests for Connection.connect method."""
+
+    @patch('gakido.connection.socket.create_connection')
+    def test_connect_http(self, mock_create_conn):
+        """Test HTTP connection (no TLS)."""
+        mock_sock = MagicMock()
+        mock_create_conn.return_value = mock_sock
+
+        conn = Connection(
+            host="example.com",
+            port=80,
+            scheme="http",
+            profile={},
+        )
+        conn.connect()
+
+        mock_create_conn.assert_called_once_with(("example.com", 80), timeout=10.0)
+        mock_sock.settimeout.assert_called_once_with(10.0)
+        assert conn.sock is mock_sock
+        assert conn.closed is False
+
+    @patch('gakido.connection.ssl.create_default_context')
+    @patch('gakido.connection.socket.create_connection')
+    def test_connect_https(self, mock_create_conn, mock_ssl_ctx):
+        """Test HTTPS connection with TLS."""
+        mock_sock = MagicMock()
+        mock_wrapped = MagicMock()
+        mock_wrapped.selected_alpn_protocol.return_value = "http/1.1"
+        mock_create_conn.return_value = mock_sock
+        mock_ctx = MagicMock()
+        mock_ctx.wrap_socket.return_value = mock_wrapped
+        mock_ssl_ctx.return_value = mock_ctx
+
+        conn = Connection(
+            host="example.com",
+            port=443,
+            scheme="https",
+            profile={"tls": {"ciphers": "TLS_AES_128_GCM_SHA256"}},
+        )
+        conn.connect()
+
+        assert conn.sock is mock_wrapped
+        assert conn.negotiated_protocol == "http/1.1"
+        assert conn.closed is False
+
+    @patch('gakido.connection.ssl.create_default_context')
+    @patch('gakido.connection.socket.create_connection')
+    def test_connect_https_verify_false(self, mock_create_conn, mock_ssl_ctx):
+        """Test HTTPS connection with verify=False."""
+        mock_sock = MagicMock()
+        mock_wrapped = MagicMock()
+        mock_wrapped.selected_alpn_protocol.return_value = None
+        mock_create_conn.return_value = mock_sock
+        mock_ctx = MagicMock()
+        mock_ctx.wrap_socket.return_value = mock_wrapped
+        mock_ssl_ctx.return_value = mock_ctx
+
+        conn = Connection(
+            host="example.com",
+            port=443,
+            scheme="https",
+            profile={},
+            verify=False,
+        )
+        conn.connect()
+
+        assert mock_ctx.check_hostname is False
+        assert mock_ctx.verify_mode == ssl.CERT_NONE
+
+    @patch('gakido.connection.ssl.create_default_context')
+    @patch('gakido.connection.socket.create_connection')
+    def test_connect_with_alpn(self, mock_create_conn, mock_ssl_ctx):
+        """Test HTTPS connection with ALPN protocols."""
+        mock_sock = MagicMock()
+        mock_wrapped = MagicMock()
+        mock_wrapped.selected_alpn_protocol.return_value = "h2"
+        mock_create_conn.return_value = mock_sock
+        mock_ctx = MagicMock()
+        mock_ctx.wrap_socket.return_value = mock_wrapped
+        mock_ssl_ctx.return_value = mock_ctx
+
+        conn = Connection(
+            host="example.com",
+            port=443,
+            scheme="https",
+            profile={"tls": {"alpn": ["h2", "http/1.1"]}},
+        )
+        conn.connect()
+
+        mock_ctx.set_alpn_protocols.assert_called_once_with(["h2", "http/1.1"])
+
+    @patch('gakido.connection.ssl.create_default_context')
+    @patch('gakido.connection.socket.create_connection')
+    def test_connect_with_http2_alpn_fallback(self, mock_create_conn, mock_ssl_ctx):
+        """Test HTTPS connection falls back to http2 alpn."""
+        mock_sock = MagicMock()
+        mock_wrapped = MagicMock()
+        mock_wrapped.selected_alpn_protocol.return_value = "h2"
+        mock_create_conn.return_value = mock_sock
+        mock_ctx = MagicMock()
+        mock_ctx.wrap_socket.return_value = mock_wrapped
+        mock_ssl_ctx.return_value = mock_ctx
+
+        conn = Connection(
+            host="example.com",
+            port=443,
+            scheme="https",
+            profile={"http2": {"alpn": ["h2"]}},  # No tls.alpn, use http2.alpn
+        )
+        conn.connect()
+
+        mock_ctx.set_alpn_protocols.assert_called_once_with(["h2"])
+
+    @patch('gakido.connection.ssl.create_default_context')
+    @patch('gakido.connection.socket.create_connection')
+    def test_connect_with_curves(self, mock_create_conn, mock_ssl_ctx):
+        """Test HTTPS connection with TLS curves."""
+        mock_sock = MagicMock()
+        mock_wrapped = MagicMock()
+        mock_wrapped.selected_alpn_protocol.return_value = None
+        mock_create_conn.return_value = mock_sock
+        mock_ctx = MagicMock()
+        mock_ctx.wrap_socket.return_value = mock_wrapped
+        mock_ssl_ctx.return_value = mock_ctx
+
+        conn = Connection(
+            host="example.com",
+            port=443,
+            scheme="https",
+            profile={"tls": {"curves": ["X25519", "P-256"]}},
+        )
+        conn.connect()
+
+        mock_ctx.set_ecdh_curve.assert_called_once_with("X25519")
+
+    @patch('gakido.connection.socket.create_connection')
+    def test_connect_tcp_failure_raises(self, mock_create_conn):
+        """Test TCP connection failure raises ConnectionError."""
+        mock_create_conn.side_effect = OSError("Connection refused")
+
+        conn = Connection(
+            host="example.com",
+            port=80,
+            scheme="http",
+            profile={},
+        )
+
+        with pytest.raises(ConnectionError, match="TCP connection failed"):
+            conn.connect()
+
+    @patch('gakido.connection.ssl.create_default_context')
+    @patch('gakido.connection.socket.create_connection')
+    def test_connect_tls_failure_retries_and_raises(self, mock_create_conn, mock_ssl_ctx):
+        """Test TLS handshake failure retries then raises TLSNegotiationError."""
+        mock_sock = MagicMock()
+        mock_create_conn.return_value = mock_sock
+        mock_ctx = MagicMock()
+        mock_ctx.wrap_socket.side_effect = ssl.SSLError("handshake failure")
+        mock_ssl_ctx.return_value = mock_ctx
+
+        conn = Connection(
+            host="example.com",
+            port=443,
+            scheme="https",
+            profile={"tls": {"ciphers": "invalid"}},
+        )
+
+        with pytest.raises(TLSNegotiationError, match="TLS handshake failed"):
+            conn.connect()
+
+    @patch('gakido.connection.ssl.create_default_context')
+    @patch('gakido.connection.socket.create_connection')
+    def test_connect_cipher_fallback(self, mock_create_conn, mock_ssl_ctx):
+        """Test cipher fallback when custom ciphers fail."""
+        mock_sock = MagicMock()
+        mock_wrapped = MagicMock()
+        mock_wrapped.selected_alpn_protocol.return_value = None
+        mock_create_conn.return_value = mock_sock
+        mock_ctx = MagicMock()
+        mock_ctx.set_ciphers.side_effect = [ssl.SSLError("bad cipher"), None]
+        mock_ctx.wrap_socket.return_value = mock_wrapped
+        mock_ssl_ctx.return_value = mock_ctx
+
+        conn = Connection(
+            host="example.com",
+            port=443,
+            scheme="https",
+            profile={"tls": {"ciphers": "invalid_cipher"}},
+        )
+        conn.connect()
+
+        assert mock_ctx.set_ciphers.call_count == 2
+
+    @patch('gakido.connection.ssl.create_default_context')
+    @patch('gakido.connection.socket.create_connection')
+    def test_connect_alpn_not_implemented(self, mock_create_conn, mock_ssl_ctx):
+        """Test ALPN NotImplementedError is handled."""
+        mock_sock = MagicMock()
+        mock_wrapped = MagicMock()
+        mock_wrapped.selected_alpn_protocol.return_value = None
+        mock_create_conn.return_value = mock_sock
+        mock_ctx = MagicMock()
+        mock_ctx.set_alpn_protocols.side_effect = NotImplementedError()
+        mock_ctx.wrap_socket.return_value = mock_wrapped
+        mock_ssl_ctx.return_value = mock_ctx
+
+        conn = Connection(
+            host="example.com",
+            port=443,
+            scheme="https",
+            profile={"tls": {"alpn": ["h2"]}},
+        )
+        # Should not raise
+        conn.connect()
+        assert conn.sock is not None
+
+
+class TestConnectionRequest:
+    """Tests for Connection.request method."""
+
+    @patch('gakido.connection.socket.create_connection')
+    def test_request_connects_if_closed(self, mock_create_conn):
+        """Test request calls connect if socket is closed."""
+        mock_sock = MagicMock()
+        mock_create_conn.return_value = mock_sock
+
+        # Set up response
+        mock_sock.recv.side_effect = [
+            b"HTTP/1.1 200 OK\r\n",
+            b"Content-Length: 4\r\n",
+            b"\r\n",
+            b"body",
+        ]
+
+        conn = Connection(
+            host="example.com",
+            port=80,
+            scheme="http",
+            profile={},
+        )
+
+        response = conn.request("GET", "/", [("Host", "example.com")])
+
+        assert response.status_code == 200
+        mock_create_conn.assert_called()
+
+    @patch('gakido.connection.socket.create_connection')
+    def test_request_send_failure_closes_connection(self, mock_create_conn):
+        """Test send failure closes connection and raises."""
+        mock_sock = MagicMock()
+        mock_sock.sendall.side_effect = OSError("broken pipe")
+        mock_create_conn.return_value = mock_sock
+
+        conn = Connection(
+            host="example.com",
+            port=80,
+            scheme="http",
+            profile={},
+        )
+        conn.connect()
+
+        with pytest.raises(ConnectionError, match="Send failed"):
+            conn.request("GET", "/", [("Host", "example.com")])
+
+        assert conn.closed is True
+
+
+class TestConnectionReadResponse:
+    """Tests for Connection._read_response method."""
+
+    @patch('gakido.connection.socket.create_connection')
+    def test_read_response_chunked(self, mock_create_conn):
+        """Test reading chunked transfer-encoded response."""
+        mock_sock = MagicMock()
+        mock_create_conn.return_value = mock_sock
+
+        # Chunked response
+        response_data = (
+            b"HTTP/1.1 200 OK\r\n"
+            b"Transfer-Encoding: chunked\r\n"
+            b"\r\n"
+            b"5\r\n"
+            b"hello\r\n"
+            b"0\r\n"
+            b"\r\n"
+        )
+        mock_sock.recv.side_effect = lambda n: response_data[:n] if n == 1 else response_data
+
+        # Use byte-by-byte recv for _readline
+        idx = [0]
+        def recv_side_effect(n):
+            if n == 1:
+                if idx[0] < len(response_data):
+                    result = response_data[idx[0]:idx[0]+1]
+                    idx[0] += 1
+                    return result
+                return b""
+            else:
+                start = idx[0]
+                idx[0] += n
+                return response_data[start:start+n]
+
+        mock_sock.recv.side_effect = recv_side_effect
+
+        conn = Connection(
+            host="example.com",
+            port=80,
+            scheme="http",
+            profile={},
+        )
+        conn.connect()
+
+        response = conn.request("GET", "/", [("Host", "example.com")])
+        assert response.status_code == 200
+        assert response.content == b"hello"
+
+    @patch('gakido.connection.socket.create_connection')
+    def test_read_response_content_length(self, mock_create_conn):
+        """Test reading response with Content-Length."""
+        mock_sock = MagicMock()
+        mock_create_conn.return_value = mock_sock
+
+        response_data = (
+            b"HTTP/1.1 200 OK\r\n"
+            b"Content-Length: 5\r\n"
+            b"\r\n"
+            b"hello"
+        )
+
+        idx = [0]
+        def recv_side_effect(n):
+            if idx[0] >= len(response_data):
+                return b""
+            if n == 1:
+                result = response_data[idx[0]:idx[0]+1]
+                idx[0] += 1
+                return result
+            else:
+                start = idx[0]
+                end = min(start + n, len(response_data))
+                idx[0] = end
+                return response_data[start:end]
+
+        mock_sock.recv.side_effect = recv_side_effect
+
+        conn = Connection(
+            host="example.com",
+            port=80,
+            scheme="http",
+            profile={},
+        )
+        conn.connect()
+
+        response = conn.request("GET", "/", [("Host", "example.com")])
+        assert response.status_code == 200
+        assert response.content == b"hello"
+
+    @patch('gakido.connection.socket.create_connection')
+    def test_read_response_empty_raises(self, mock_create_conn):
+        """Test empty response raises ProtocolError."""
+        mock_sock = MagicMock()
+        mock_sock.recv.return_value = b""
+        mock_create_conn.return_value = mock_sock
+
+        conn = Connection(
+            host="example.com",
+            port=80,
+            scheme="http",
+            profile={},
+        )
+        conn.connect()
+
+        with pytest.raises(ProtocolError, match="Empty response"):
+            conn.request("GET", "/", [("Host", "example.com")])
+
+    @patch('gakido.connection.socket.create_connection')
+    def test_read_response_malformed_status_raises(self, mock_create_conn):
+        """Test malformed status line raises ProtocolError."""
+        mock_sock = MagicMock()
+        mock_create_conn.return_value = mock_sock
+
+        idx = [0]
+        response_data = b"INVALID_STATUS\r\n"
+        def recv_side_effect(n):
+            if idx[0] >= len(response_data):
+                return b""
+            if n == 1:
+                result = response_data[idx[0]:idx[0]+1]
+                idx[0] += 1
+                return result
+            return b""
+
+        mock_sock.recv.side_effect = recv_side_effect
+
+        conn = Connection(
+            host="example.com",
+            port=80,
+            scheme="http",
+            profile={},
+        )
+        conn.connect()
+
+        with pytest.raises(ProtocolError, match="Malformed status line"):
+            conn.request("GET", "/", [("Host", "example.com")])
+
+    @patch('gakido.connection.socket.create_connection')
+    def test_read_response_connection_close(self, mock_create_conn):
+        """Test Connection: close header closes connection."""
+        mock_sock = MagicMock()
+        mock_create_conn.return_value = mock_sock
+
+        response_data = (
+            b"HTTP/1.1 200 OK\r\n"
+            b"Connection: close\r\n"
+            b"Content-Length: 5\r\n"
+            b"\r\n"
+            b"hello"
+        )
+
+        idx = [0]
+        def recv_side_effect(n):
+            if idx[0] >= len(response_data):
+                return b""
+            if n == 1:
+                result = response_data[idx[0]:idx[0]+1]
+                idx[0] += 1
+                return result
+            else:
+                start = idx[0]
+                end = min(start + n, len(response_data))
+                idx[0] = end
+                return response_data[start:end]
+
+        mock_sock.recv.side_effect = recv_side_effect
+
+        conn = Connection(
+            host="example.com",
+            port=80,
+            scheme="http",
+            profile={},
+        )
+        conn.connect()
+
+        response = conn.request("GET", "/", [("Host", "example.com")])
+        assert conn.closed is True
+
+
+class TestConnectionClose:
+    """Tests for Connection.close method."""
+
+    @patch('gakido.connection.socket.create_connection')
+    def test_close_closes_socket(self, mock_create_conn):
+        """Test close closes the socket."""
+        mock_sock = MagicMock()
+        mock_create_conn.return_value = mock_sock
+
+        conn = Connection(
+            host="example.com",
+            port=80,
+            scheme="http",
+            profile={},
+        )
+        conn.connect()
+        conn.close()
+
+        mock_sock.close.assert_called_once()
+        assert conn.sock is None
+        assert conn.closed is True
+
+    def test_close_when_already_closed(self):
+        """Test close when already closed does nothing."""
+        conn = Connection(
+            host="example.com",
+            port=80,
+            scheme="http",
+            profile={},
+        )
+        # Already closed, should not raise
+        conn.close()
+        assert conn.closed is True
+
+
+class TestConnectionBuildRequest:
+    """Tests for Connection._build_request method."""
+
+    def test_build_request_get(self):
+        """Test building GET request."""
+        conn = Connection(
+            host="example.com",
+            port=80,
+            scheme="http",
+            profile={},
+        )
+
+        request = conn._build_request(
+            "GET",
+            "/path",
+            [("Host", "example.com"), ("User-Agent", "test")],
+            None,
+        )
+
+        assert b"GET /path HTTP/1.1\r\n" in request
+        assert b"Host: example.com\r\n" in request
+        assert b"User-Agent: test\r\n" in request
+
+    def test_build_request_post_with_body(self):
+        """Test building POST request with body."""
+        conn = Connection(
+            host="example.com",
+            port=80,
+            scheme="http",
+            profile={},
+        )
+
+        request = conn._build_request(
+            "POST",
+            "/submit",
+            [("Host", "example.com"), ("Content-Length", "4")],
+            b"data",
+        )
+
+        assert b"POST /submit HTTP/1.1\r\n" in request
+        assert request.endswith(b"\r\n\r\ndata")
+
+
+class TestConnectionH2:
+    """Tests for Connection HTTP/2 path."""
+
+    @patch('gakido.connection.HTTP2Connection')
+    @patch('gakido.connection.ssl.create_default_context')
+    @patch('gakido.connection.socket.create_connection')
+    def test_request_uses_h2_when_negotiated(self, mock_create_conn, mock_ssl_ctx, mock_h2_conn):
+        """Test request uses HTTP2Connection when h2 negotiated."""
+        mock_sock = MagicMock()
+        mock_wrapped = MagicMock()
+        mock_wrapped.selected_alpn_protocol.return_value = "h2"
+        mock_create_conn.return_value = mock_sock
+        mock_ctx = MagicMock()
+        mock_ctx.wrap_socket.return_value = mock_wrapped
+        mock_ssl_ctx.return_value = mock_ctx
+
+        mock_h2_response = Response(200, "OK", "2", [], b"body")
+        mock_h2_conn.return_value.request.return_value = mock_h2_response
+
+        conn = Connection(
+            host="example.com",
+            port=443,
+            scheme="https",
+            profile={"tls": {"alpn": ["h2", "http/1.1"]}},
+        )
+        conn.connect()
+
+        response = conn.request("GET", "/", [("Host", "example.com")])
+
+        assert response.http_version == "2"
+        mock_h2_conn.assert_called_once_with(mock_wrapped)
+
+
+class TestConnectionReadHelpers:
+    """Tests for Connection read helper methods."""
+
+    @patch('gakido.connection.socket.create_connection')
+    def test_read_exact_eof_raises(self, mock_create_conn):
+        """Test _read_exact raises on unexpected EOF."""
+        mock_sock = MagicMock()
+        mock_sock.recv.side_effect = [b"partial", b""]
+        mock_create_conn.return_value = mock_sock
+
+        conn = Connection(
+            host="example.com",
+            port=80,
+            scheme="http",
+            profile={},
+        )
+        conn.connect()
+
+        with pytest.raises(ProtocolError, match="Unexpected EOF"):
+            conn._read_exact(100)
+
+    @patch('gakido.connection.socket.create_connection')
+    def test_read_until_close_timeout(self, mock_create_conn):
+        """Test _read_until_close handles timeout."""
+        mock_sock = MagicMock()
+        mock_sock.recv.side_effect = [b"data1", b"data2", TimeoutError()]
+        mock_create_conn.return_value = mock_sock
+
+        conn = Connection(
+            host="example.com",
+            port=80,
+            scheme="http",
+            profile={},
+        )
+        conn.connect()
+
+        result = conn._read_until_close()
+        assert result == b"data1data2"
+
+    @patch('gakido.connection.socket.create_connection')
+    def test_readline(self, mock_create_conn):
+        """Test _readline reads until CRLF."""
+        mock_sock = MagicMock()
+        mock_create_conn.return_value = mock_sock
+
+        line_data = b"Hello World\r\n"
+        idx = [0]
+        def recv_one(n):
+            if idx[0] >= len(line_data):
+                return b""
+            result = line_data[idx[0]:idx[0]+1]
+            idx[0] += 1
+            return result
+
+        mock_sock.recv.side_effect = recv_one
+
+        conn = Connection(
+            host="example.com",
+            port=80,
+            scheme="http",
+            profile={},
+        )
+        conn.connect()
+
+        result = conn._readline()
+        assert result == b"Hello World\r\n"

--- a/tests/test_cookies.py
+++ b/tests/test_cookies.py
@@ -1,0 +1,112 @@
+"""Tests for gakido.cookies module."""
+
+import pytest
+from gakido.cookies import CookieJar
+
+
+class TestCookieJar:
+    """Tests for CookieJar class."""
+
+    def test_empty_jar(self):
+        """Test empty cookie jar returns None for header."""
+        jar = CookieJar()
+        assert jar.cookie_header("example.com") is None
+
+    def test_set_single_cookie(self):
+        """Test setting a single cookie."""
+        jar = CookieJar()
+        headers = [("Set-Cookie", "session=abc123")]
+        jar.set_from_headers(headers, "example.com")
+
+        assert jar.cookie_header("example.com") == "session=abc123"
+
+    def test_set_multiple_cookies(self):
+        """Test setting multiple cookies."""
+        jar = CookieJar()
+        headers = [
+            ("Set-Cookie", "session=abc123"),
+            ("Set-Cookie", "user=john"),
+        ]
+        jar.set_from_headers(headers, "example.com")
+
+        cookie = jar.cookie_header("example.com")
+        assert "session=abc123" in cookie
+        assert "user=john" in cookie
+
+    def test_cookies_are_host_scoped(self):
+        """Test cookies are scoped to host."""
+        jar = CookieJar()
+        jar.set_from_headers([("Set-Cookie", "a=1")], "example.com")
+        jar.set_from_headers([("Set-Cookie", "b=2")], "other.com")
+
+        assert jar.cookie_header("example.com") == "a=1"
+        assert jar.cookie_header("other.com") == "b=2"
+        assert jar.cookie_header("unknown.com") is None
+
+    def test_cookie_overwrite(self):
+        """Test setting same cookie name overwrites."""
+        jar = CookieJar()
+        jar.set_from_headers([("Set-Cookie", "session=old")], "example.com")
+        jar.set_from_headers([("Set-Cookie", "session=new")], "example.com")
+
+        assert jar.cookie_header("example.com") == "session=new"
+
+    def test_ignores_non_set_cookie_headers(self):
+        """Test non Set-Cookie headers are ignored."""
+        jar = CookieJar()
+        headers = [
+            ("Content-Type", "text/html"),
+            ("Set-Cookie", "session=abc"),
+            ("X-Custom", "value"),
+        ]
+        jar.set_from_headers(headers, "example.com")
+
+        assert jar.cookie_header("example.com") == "session=abc"
+
+    def test_cookie_with_attributes(self):
+        """Test cookie with attributes (Path, Expires, etc)."""
+        jar = CookieJar()
+        headers = [("Set-Cookie", "session=abc; Path=/; HttpOnly; Secure")]
+        jar.set_from_headers(headers, "example.com")
+
+        # Only the name=value should be in the header
+        assert jar.cookie_header("example.com") == "session=abc"
+
+    def test_repr(self):
+        """Test CookieJar repr."""
+        jar = CookieJar()
+        jar.set_from_headers([("Set-Cookie", "a=1")], "example.com")
+
+        repr_str = repr(jar)
+        assert "Cookies" in repr_str
+        assert "example.com" in repr_str
+
+    def test_multiple_hosts_isolated(self):
+        """Test cookies for different hosts don't mix."""
+        jar = CookieJar()
+        jar.set_from_headers([("Set-Cookie", "token=xyz")], "api.example.com")
+        jar.set_from_headers([("Set-Cookie", "token=abc")], "www.example.com")
+
+        assert jar.cookie_header("api.example.com") == "token=xyz"
+        assert jar.cookie_header("www.example.com") == "token=abc"
+
+    def test_empty_headers_list(self):
+        """Test empty headers list doesn't raise."""
+        jar = CookieJar()
+        jar.set_from_headers([], "example.com")
+        assert jar.cookie_header("example.com") is None
+
+    def test_cookie_header_format(self):
+        """Test cookie header format with multiple cookies."""
+        jar = CookieJar()
+        jar.set_from_headers([
+            ("Set-Cookie", "a=1"),
+            ("Set-Cookie", "b=2"),
+            ("Set-Cookie", "c=3"),
+        ], "example.com")
+
+        cookie = jar.cookie_header("example.com")
+        # Should be semicolon-separated
+        assert "; " in cookie
+        parts = cookie.split("; ")
+        assert len(parts) == 3

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,0 +1,107 @@
+"""Tests for gakido.errors module."""
+
+import pytest
+from gakido.errors import (
+    GakidoError,
+    ConnectionError,
+    TLSNegotiationError,
+    ProtocolError,
+    HTTPError,
+    HTTP3NotAvailableError,
+)
+
+
+class TestErrorHierarchy:
+    """Tests for error class hierarchy."""
+
+    def test_gakido_error_is_exception(self):
+        """Test GakidoError inherits from Exception."""
+        assert issubclass(GakidoError, Exception)
+
+    def test_connection_error_inherits_gakido_error(self):
+        """Test ConnectionError inherits from GakidoError."""
+        assert issubclass(ConnectionError, GakidoError)
+
+    def test_tls_negotiation_error_inherits_connection_error(self):
+        """Test TLSNegotiationError inherits from ConnectionError."""
+        assert issubclass(TLSNegotiationError, ConnectionError)
+        assert issubclass(TLSNegotiationError, GakidoError)
+
+    def test_protocol_error_inherits_gakido_error(self):
+        """Test ProtocolError inherits from GakidoError."""
+        assert issubclass(ProtocolError, GakidoError)
+
+    def test_http_error_inherits_gakido_error(self):
+        """Test HTTPError inherits from GakidoError."""
+        assert issubclass(HTTPError, GakidoError)
+
+    def test_http3_not_available_error_inherits_gakido_error(self):
+        """Test HTTP3NotAvailableError inherits from GakidoError."""
+        assert issubclass(HTTP3NotAvailableError, GakidoError)
+
+
+class TestErrorInstantiation:
+    """Tests for error instantiation."""
+
+    def test_gakido_error_with_message(self):
+        """Test GakidoError can be raised with message."""
+        with pytest.raises(GakidoError, match="test message"):
+            raise GakidoError("test message")
+
+    def test_connection_error_with_message(self):
+        """Test ConnectionError can be raised with message."""
+        with pytest.raises(ConnectionError, match="connection failed"):
+            raise ConnectionError("connection failed")
+
+    def test_tls_negotiation_error_with_message(self):
+        """Test TLSNegotiationError can be raised with message."""
+        with pytest.raises(TLSNegotiationError, match="TLS handshake"):
+            raise TLSNegotiationError("TLS handshake failed")
+
+    def test_protocol_error_with_message(self):
+        """Test ProtocolError can be raised with message."""
+        with pytest.raises(ProtocolError, match="invalid response"):
+            raise ProtocolError("invalid response")
+
+    def test_http_error_with_message(self):
+        """Test HTTPError can be raised with message."""
+        with pytest.raises(HTTPError, match="404 Not Found"):
+            raise HTTPError("404 Not Found")
+
+    def test_http3_not_available_error_with_message(self):
+        """Test HTTP3NotAvailableError can be raised with message."""
+        with pytest.raises(HTTP3NotAvailableError, match="aioquic"):
+            raise HTTP3NotAvailableError("aioquic not installed")
+
+
+class TestErrorCatching:
+    """Tests for catching errors at different hierarchy levels."""
+
+    def test_catch_tls_error_as_connection_error(self):
+        """Test TLSNegotiationError can be caught as ConnectionError."""
+        try:
+            raise TLSNegotiationError("TLS failed")
+        except ConnectionError as e:
+            assert "TLS failed" in str(e)
+
+    def test_catch_connection_error_as_gakido_error(self):
+        """Test ConnectionError can be caught as GakidoError."""
+        try:
+            raise ConnectionError("connection failed")
+        except GakidoError as e:
+            assert "connection failed" in str(e)
+
+    def test_catch_all_as_gakido_error(self):
+        """Test all custom errors can be caught as GakidoError."""
+        errors = [
+            ConnectionError("conn"),
+            TLSNegotiationError("tls"),
+            ProtocolError("proto"),
+            HTTPError("http"),
+            HTTP3NotAvailableError("h3"),
+        ]
+        for error in errors:
+            try:
+                raise error
+            except GakidoError:
+                pass  # Should catch all

--- a/tests/test_fingerprints.py
+++ b/tests/test_fingerprints.py
@@ -1,0 +1,86 @@
+"""Tests for gakido.fingerprints module."""
+
+import pytest
+from gakido.fingerprints import ExtraFingerprints
+
+
+class TestExtraFingerprints:
+    """Tests for ExtraFingerprints class."""
+
+    def test_default_initialization(self):
+        """Test default initialization with empty lists."""
+        fp = ExtraFingerprints()
+        assert fp.alpn == []
+        assert fp.ciphers == []
+        assert fp.curves == []
+        assert fp.sig_algs == []
+        assert fp.extensions == []
+
+    def test_initialization_with_alpn(self):
+        """Test initialization with ALPN protocols."""
+        fp = ExtraFingerprints(alpn=["h2", "http/1.1"])
+        assert fp.alpn == ["h2", "http/1.1"]
+        assert fp.ciphers == []
+
+    def test_initialization_with_ciphers(self):
+        """Test initialization with cipher suites."""
+        ciphers = ["TLS_AES_128_GCM_SHA256", "TLS_AES_256_GCM_SHA384"]
+        fp = ExtraFingerprints(ciphers=ciphers)
+        assert fp.ciphers == ciphers
+
+    def test_initialization_with_curves(self):
+        """Test initialization with elliptic curves."""
+        curves = ["X25519", "prime256v1"]
+        fp = ExtraFingerprints(curves=curves)
+        assert fp.curves == curves
+
+    def test_initialization_with_sig_algs(self):
+        """Test initialization with signature algorithms."""
+        sig_algs = ["ecdsa_secp256r1_sha256", "rsa_pss_rsae_sha256"]
+        fp = ExtraFingerprints(sig_algs=sig_algs)
+        assert fp.sig_algs == sig_algs
+
+    def test_initialization_with_extensions(self):
+        """Test initialization with TLS extensions."""
+        extensions = ["server_name", "supported_versions"]
+        fp = ExtraFingerprints(extensions=extensions)
+        assert fp.extensions == extensions
+
+    def test_initialization_with_all_params(self):
+        """Test initialization with all parameters."""
+        fp = ExtraFingerprints(
+            alpn=["h2"],
+            ciphers=["cipher1"],
+            curves=["X25519"],
+            sig_algs=["sig1"],
+            extensions=["ext1"],
+        )
+        assert fp.alpn == ["h2"]
+        assert fp.ciphers == ["cipher1"]
+        assert fp.curves == ["X25519"]
+        assert fp.sig_algs == ["sig1"]
+        assert fp.extensions == ["ext1"]
+
+    def test_none_values_become_empty_lists(self):
+        """Test None values are converted to empty lists."""
+        fp = ExtraFingerprints(
+            alpn=None,
+            ciphers=None,
+            curves=None,
+            sig_algs=None,
+            extensions=None,
+        )
+        assert fp.alpn == []
+        assert fp.ciphers == []
+        assert fp.curves == []
+        assert fp.sig_algs == []
+        assert fp.extensions == []
+
+    def test_lists_are_stored_by_reference(self):
+        """Test lists passed in are stored (not copied)."""
+        alpn_list = ["h2"]
+        fp = ExtraFingerprints(alpn=alpn_list)
+        # Modifying the original list affects the stored value
+        # (This is expected Python behavior, documenting it)
+        alpn_list.append("http/1.1")
+        assert "http/1.1" in fp.alpn

--- a/tests/test_headers.py
+++ b/tests/test_headers.py
@@ -1,13 +1,122 @@
+"""Tests for gakido.headers module."""
+
+import pytest
 from gakido.headers import canonicalize_headers
 
 
-def test_header_ordering_merges_and_respects_order():
-    default = [("User-Agent", "ua"), ("Accept", "*/*")]
-    user = {"Accept": "json", "X-Test": "1"}
-    order = ["Accept", "User-Agent", "X-Test"]
-    merged = canonicalize_headers(default, user, order)
-    assert merged == [
-        ("Accept", "json"),
-        ("User-Agent", "ua"),
-        ("X-Test", "1"),
-    ]
+class TestCanonicalizeHeaders:
+    """Tests for canonicalize_headers function."""
+
+    def test_header_ordering_merges_and_respects_order(self):
+        """Test headers are merged and ordered correctly."""
+        default = [("User-Agent", "ua"), ("Accept", "*/*")]
+        user = {"Accept": "json", "X-Test": "1"}
+        order = ["Accept", "User-Agent", "X-Test"]
+        merged = canonicalize_headers(default, user, order)
+        assert merged == [
+            ("Accept", "json"),
+            ("User-Agent", "ua"),
+            ("X-Test", "1"),
+        ]
+
+    def test_empty_defaults(self):
+        """Test with empty default headers."""
+        merged = canonicalize_headers([], {"X-Test": "1"}, ["X-Test"])
+        assert merged == [("X-Test", "1")]
+
+    def test_empty_user_headers(self):
+        """Test with no user headers."""
+        default = [("User-Agent", "ua")]
+        merged = canonicalize_headers(default, None, ["User-Agent"])
+        assert merged == [("User-Agent", "ua")]
+
+    def test_empty_dict_user_headers(self):
+        """Test with empty dict user headers."""
+        default = [("User-Agent", "ua")]
+        merged = canonicalize_headers(default, {}, ["User-Agent"])
+        assert merged == [("User-Agent", "ua")]
+
+    def test_empty_order(self):
+        """Test with empty order list."""
+        default = [("A", "1"), ("B", "2")]
+        user = {"C": "3"}
+        merged = canonicalize_headers(default, user, [])
+        # All headers should be present but unordered
+        keys = [h[0] for h in merged]
+        assert "A" in keys
+        assert "B" in keys
+        assert "C" in keys
+
+    def test_case_insensitive_merge(self):
+        """Test header names are merged case-insensitively."""
+        default = [("Content-Type", "text/html")]
+        user = {"content-type": "application/json"}
+        merged = canonicalize_headers(default, user, ["Content-Type"])
+        # User value should win
+        assert len(merged) == 1
+        assert merged[0][1] == "application/json"
+
+    def test_case_insensitive_ordering(self):
+        """Test ordering is case-insensitive."""
+        default = [("ACCEPT", "text/html")]
+        merged = canonicalize_headers(default, None, ["accept"])
+        assert merged == [("ACCEPT", "text/html")]
+
+    def test_preserves_original_case(self):
+        """Test original header name case is preserved."""
+        default = [("X-Custom-Header", "value")]
+        merged = canonicalize_headers(default, None, ["x-custom-header"])
+        assert merged[0][0] == "X-Custom-Header"
+
+    def test_user_overrides_default(self):
+        """Test user headers override defaults."""
+        default = [("Accept", "text/html")]
+        user = {"Accept": "application/json"}
+        merged = canonicalize_headers(default, user, ["Accept"])
+        assert merged[0][1] == "application/json"
+
+    def test_unordered_headers_appended(self):
+        """Test headers not in order list are appended."""
+        default = [("A", "1")]
+        user = {"B": "2", "C": "3"}
+        order = ["A"]
+        merged = canonicalize_headers(default, user, order)
+        # A should be first, B and C after
+        assert merged[0] == ("A", "1")
+        remaining = merged[1:]
+        keys = [h[0] for h in remaining]
+        assert "B" in keys
+        assert "C" in keys
+
+    def test_multiple_defaults_same_key(self):
+        """Test multiple defaults with same key use last."""
+        default = [("Accept", "first"), ("Accept", "second")]
+        merged = canonicalize_headers(default, None, ["Accept"])
+        # Last one wins
+        assert merged == [("Accept", "second")]
+
+    def test_complex_ordering(self):
+        """Test complex ordering scenario."""
+        default = [
+            ("Host", "example.com"),
+            ("User-Agent", "test"),
+            ("Accept", "text/html"),
+        ]
+        user = {
+            "Accept": "application/json",
+            "X-Custom": "value",
+        }
+        order = ["Host", "Accept", "User-Agent", "X-Custom"]
+        merged = canonicalize_headers(default, user, order)
+
+        expected_order = ["Host", "Accept", "User-Agent", "X-Custom"]
+        actual_order = [h[0] for h in merged]
+        assert actual_order == expected_order
+
+    def test_order_with_missing_headers(self):
+        """Test order list with headers not present."""
+        default = [("A", "1")]
+        order = ["Z", "A", "Y"]  # Z and Y don't exist
+        merged = canonicalize_headers(default, None, order)
+        # Should only have A
+        assert merged == [("A", "1")]

--- a/tests/test_http2.py
+++ b/tests/test_http2.py
@@ -1,0 +1,330 @@
+"""Tests for gakido.http2 module."""
+
+import pytest
+from unittest.mock import Mock, MagicMock, patch
+import ssl
+
+from gakido.http2 import HTTP2Connection
+from gakido.models import Response
+from gakido.errors import ProtocolError
+
+
+class TestHTTP2ConnectionInit:
+    """Tests for HTTP2Connection initialization."""
+
+    @patch('gakido.http2.h2.connection.H2Connection')
+    def test_init_initiates_connection(self, mock_h2_conn_class):
+        """Test HTTP2Connection initiates h2 connection."""
+        mock_sock = MagicMock()
+        mock_h2_conn = MagicMock()
+        mock_h2_conn.data_to_send.return_value = b"preface"
+        mock_h2_conn_class.return_value = mock_h2_conn
+
+        h2 = HTTP2Connection(mock_sock)
+
+        mock_h2_conn.initiate_connection.assert_called_once()
+        mock_sock.sendall.assert_called_once_with(b"preface")
+
+    @patch('gakido.http2.h2.connection.H2Connection')
+    def test_init_stores_socket(self, mock_h2_conn_class):
+        """Test HTTP2Connection stores socket reference."""
+        mock_sock = MagicMock()
+        mock_h2_conn = MagicMock()
+        mock_h2_conn.data_to_send.return_value = b""
+        mock_h2_conn_class.return_value = mock_h2_conn
+
+        h2 = HTTP2Connection(mock_sock)
+
+        assert h2.sock is mock_sock
+
+
+class TestHTTP2ConnectionRequest:
+    """Tests for HTTP2Connection.request method."""
+
+    @patch('gakido.http2.h2.events')
+    @patch('gakido.http2.h2.connection.H2Connection')
+    def test_request_get(self, mock_h2_conn_class, mock_events):
+        """Test HTTP2 GET request."""
+        mock_sock = MagicMock()
+        mock_h2_conn = MagicMock()
+        mock_h2_conn.data_to_send.return_value = b""
+        mock_h2_conn.get_next_available_stream_id.return_value = 1
+        mock_h2_conn_class.return_value = mock_h2_conn
+
+        # Mock response events
+        mock_response_received = MagicMock()
+        mock_response_received.headers = [(b":status", b"200")]
+        mock_data_received = MagicMock()
+        mock_data_received.data = b"response body"
+        mock_data_received.flow_controlled_length = 13
+        mock_stream_ended = MagicMock()
+
+        # Configure isinstance checks
+        mock_events.ResponseReceived = type(mock_response_received)
+        mock_events.DataReceived = type(mock_data_received)
+        mock_events.StreamEnded = type(mock_stream_ended)
+
+        # First recv returns response data, second returns empty (connection close)
+        mock_sock.recv.side_effect = [b"h2data", b""]
+        mock_h2_conn.receive_data.return_value = [
+            mock_response_received,
+            mock_data_received,
+            mock_stream_ended,
+        ]
+
+        h2 = HTTP2Connection(mock_sock)
+        response = h2.request("GET", "example.com", "/path", [("accept", "*/*")])
+
+        assert response.status_code == 200
+
+    @patch('gakido.http2.h2.events')
+    @patch('gakido.http2.h2.connection.H2Connection')
+    def test_request_post_with_body(self, mock_h2_conn_class, mock_events):
+        """Test HTTP2 POST request with body."""
+        mock_sock = MagicMock()
+        mock_h2_conn = MagicMock()
+        mock_h2_conn.data_to_send.return_value = b""
+        mock_h2_conn.get_next_available_stream_id.return_value = 1
+        mock_h2_conn_class.return_value = mock_h2_conn
+
+        # Mock response events
+        mock_response_received = MagicMock()
+        mock_response_received.headers = [(b":status", b"201")]
+        mock_stream_ended = MagicMock()
+
+        mock_events.ResponseReceived = type(mock_response_received)
+        mock_events.DataReceived = MagicMock
+        mock_events.StreamEnded = type(mock_stream_ended)
+        mock_events.StreamReset = MagicMock
+
+        mock_sock.recv.side_effect = [b"h2data", b""]
+        mock_h2_conn.receive_data.return_value = [
+            mock_response_received,
+            mock_stream_ended,
+        ]
+
+        h2 = HTTP2Connection(mock_sock)
+        response = h2.request(
+            "POST",
+            "example.com",
+            "/submit",
+            [("content-type", "application/json")],
+            body=b'{"data": "value"}',
+        )
+
+        # Verify send_data was called with body
+        mock_h2_conn.send_data.assert_called_once_with(1, b'{"data": "value"}', end_stream=True)
+
+    @patch('gakido.http2.h2.connection.H2Connection')
+    def test_request_stream_reset_raises(self, mock_h2_conn_class):
+        """Test HTTP2 stream reset raises ProtocolError."""
+        import h2.events
+
+        mock_sock = MagicMock()
+        mock_h2_conn = MagicMock()
+        mock_h2_conn.data_to_send.return_value = b""
+        mock_h2_conn.get_next_available_stream_id.return_value = 1
+        mock_h2_conn_class.return_value = mock_h2_conn
+
+        # Create a real StreamReset event mock
+        mock_stream_reset = MagicMock(spec=h2.events.StreamReset)
+        mock_stream_reset.error_code = 2
+
+        mock_sock.recv.side_effect = [b"h2data", b""]
+        mock_h2_conn.receive_data.return_value = [mock_stream_reset]
+
+        h2 = HTTP2Connection(mock_sock)
+
+        with pytest.raises(ProtocolError, match="Stream reset"):
+            h2.request("GET", "example.com", "/path", [])
+
+    @patch('gakido.http2.h2.events')
+    @patch('gakido.http2.h2.connection.H2Connection')
+    def test_request_graceful_close_returns_partial(self, mock_h2_conn_class, mock_events):
+        """Test graceful close returns partial response if data received."""
+        mock_sock = MagicMock()
+        mock_h2_conn = MagicMock()
+        mock_h2_conn.data_to_send.return_value = b""
+        mock_h2_conn.get_next_available_stream_id.return_value = 1
+        mock_h2_conn_class.return_value = mock_h2_conn
+
+        # Mock response received event
+        mock_response_received = MagicMock()
+        mock_response_received.headers = [(b":status", b"200")]
+
+        mock_events.ResponseReceived = type(mock_response_received)
+        mock_events.DataReceived = MagicMock
+        mock_events.StreamEnded = MagicMock
+        mock_events.StreamReset = MagicMock
+
+        # Receive response then connection closes
+        mock_sock.recv.side_effect = [b"h2data", b""]
+        mock_h2_conn.receive_data.return_value = [mock_response_received]
+
+        h2 = HTTP2Connection(mock_sock)
+        response = h2.request("GET", "example.com", "/path", [])
+
+        # Should return partial response
+        assert response.status_code == 200
+
+    @patch('gakido.http2.h2.events')
+    @patch('gakido.http2.h2.connection.H2Connection')
+    def test_request_connection_closed_without_response_raises(self, mock_h2_conn_class, mock_events):
+        """Test connection close without any response raises ProtocolError."""
+        mock_sock = MagicMock()
+        mock_h2_conn = MagicMock()
+        mock_h2_conn.data_to_send.return_value = b""
+        mock_h2_conn.get_next_available_stream_id.return_value = 1
+        mock_h2_conn_class.return_value = mock_h2_conn
+
+        mock_events.ResponseReceived = MagicMock
+        mock_events.DataReceived = MagicMock
+        mock_events.StreamEnded = MagicMock
+        mock_events.StreamReset = MagicMock
+
+        # Immediately close connection
+        mock_sock.recv.return_value = b""
+        mock_h2_conn.receive_data.return_value = []
+
+        h2 = HTTP2Connection(mock_sock)
+
+        with pytest.raises(ProtocolError, match="Connection closed before stream ended"):
+            h2.request("GET", "example.com", "/path", [])
+
+
+class TestHTTP2ConnectionSend:
+    """Tests for HTTP2Connection._send method."""
+
+    @patch('gakido.http2.h2.connection.H2Connection')
+    def test_send_empty_data_skipped(self, mock_h2_conn_class):
+        """Test _send with empty data does nothing."""
+        mock_sock = MagicMock()
+        mock_h2_conn = MagicMock()
+        mock_h2_conn.data_to_send.return_value = b""
+        mock_h2_conn_class.return_value = mock_h2_conn
+
+        h2 = HTTP2Connection(mock_sock)
+        mock_sock.reset_mock()
+
+        h2._send(b"")
+
+        mock_sock.sendall.assert_not_called()
+
+    @patch('gakido.http2.h2.connection.H2Connection')
+    def test_send_data(self, mock_h2_conn_class):
+        """Test _send with data calls sendall."""
+        mock_sock = MagicMock()
+        mock_h2_conn = MagicMock()
+        mock_h2_conn.data_to_send.return_value = b""
+        mock_h2_conn_class.return_value = mock_h2_conn
+
+        h2 = HTTP2Connection(mock_sock)
+        mock_sock.reset_mock()
+
+        h2._send(b"data to send")
+
+        mock_sock.sendall.assert_called_once_with(b"data to send")
+
+
+class TestHTTP2ConnectionHeaders:
+    """Tests for HTTP2Connection header handling."""
+
+    @patch('gakido.http2.h2.events')
+    @patch('gakido.http2.h2.connection.H2Connection')
+    def test_request_filters_pseudo_headers(self, mock_h2_conn_class, mock_events):
+        """Test response filters out pseudo-headers from headers list."""
+        mock_sock = MagicMock()
+        mock_h2_conn = MagicMock()
+        mock_h2_conn.data_to_send.return_value = b""
+        mock_h2_conn.get_next_available_stream_id.return_value = 1
+        mock_h2_conn_class.return_value = mock_h2_conn
+
+        # Mock response with pseudo-headers and regular headers
+        mock_response_received = MagicMock()
+        mock_response_received.headers = [
+            (b":status", b"200"),
+            (b"content-type", b"text/html"),
+            (b"content-length", b"100"),
+        ]
+        mock_stream_ended = MagicMock()
+
+        mock_events.ResponseReceived = type(mock_response_received)
+        mock_events.DataReceived = MagicMock
+        mock_events.StreamEnded = type(mock_stream_ended)
+        mock_events.StreamReset = MagicMock
+
+        mock_sock.recv.side_effect = [b"h2data", b""]
+        mock_h2_conn.receive_data.return_value = [
+            mock_response_received,
+            mock_stream_ended,
+        ]
+
+        h2 = HTTP2Connection(mock_sock)
+        response = h2.request("GET", "example.com", "/", [])
+
+        # Verify pseudo-headers are not in response headers
+        header_names = [name for name, _ in response.raw_headers]
+        assert ":status" not in header_names
+        assert "content-type" in header_names
+
+    @patch('gakido.http2.h2.connection.H2Connection')
+    def test_request_handles_bytes_headers(self, mock_h2_conn_class):
+        """Test response handles bytes headers correctly."""
+        import h2.events
+
+        mock_sock = MagicMock()
+        mock_h2_conn = MagicMock()
+        mock_h2_conn.data_to_send.return_value = b""
+        mock_h2_conn.get_next_available_stream_id.return_value = 1
+        mock_h2_conn_class.return_value = mock_h2_conn
+
+        # Mock response with bytes headers (standard h2 behavior)
+        mock_response_received = MagicMock(spec=h2.events.ResponseReceived)
+        mock_response_received.headers = [
+            (b":status", b"200"),
+            (b"content-type", b"text/html"),
+        ]
+        mock_stream_ended = MagicMock(spec=h2.events.StreamEnded)
+
+        mock_sock.recv.side_effect = [b"h2data", b""]
+        mock_h2_conn.receive_data.return_value = [
+            mock_response_received,
+            mock_stream_ended,
+        ]
+
+        h2 = HTTP2Connection(mock_sock)
+        response = h2.request("GET", "example.com", "/", [])
+
+        assert response.status_code == 200
+
+
+class TestHTTP2ConnectionFlowControl:
+    """Tests for HTTP2Connection flow control."""
+
+    @patch('gakido.http2.h2.connection.H2Connection')
+    def test_request_acknowledges_received_data(self, mock_h2_conn_class):
+        """Test request acknowledges received data for flow control."""
+        import h2.events
+
+        mock_sock = MagicMock()
+        mock_h2_conn = MagicMock()
+        mock_h2_conn.data_to_send.return_value = b""
+        mock_h2_conn.get_next_available_stream_id.return_value = 1
+        mock_h2_conn_class.return_value = mock_h2_conn
+
+        # Mock data received event
+        mock_data_received = MagicMock(spec=h2.events.DataReceived)
+        mock_data_received.data = b"response body"
+        mock_data_received.flow_controlled_length = 13
+        mock_stream_ended = MagicMock(spec=h2.events.StreamEnded)
+
+        mock_sock.recv.side_effect = [b"h2data", b""]
+        mock_h2_conn.receive_data.return_value = [
+            mock_data_received,
+            mock_stream_ended,
+        ]
+
+        h2 = HTTP2Connection(mock_sock)
+        h2.request("GET", "example.com", "/", [])
+
+        mock_h2_conn.acknowledge_received_data.assert_called_with(13, 1)

--- a/tests/test_http3.py
+++ b/tests/test_http3.py
@@ -1,0 +1,448 @@
+"""Tests for gakido.http3 module."""
+
+import pytest
+from unittest.mock import Mock, MagicMock, patch, AsyncMock
+from gakido.http3 import (
+    is_http3_available,
+    parse_alt_svc,
+    HTTP3Protocol,
+    H3ResponseHandler,
+    _get_aioquic,
+)
+from gakido.errors import HTTP3NotAvailableError, ProtocolError
+
+
+class TestIsHttp3Available:
+    """Tests for is_http3_available function."""
+
+    def test_returns_boolean(self):
+        """Test function returns a boolean."""
+        result = is_http3_available()
+        assert isinstance(result, bool)
+
+    def test_consistent_results(self):
+        """Test function returns consistent results."""
+        result1 = is_http3_available()
+        result2 = is_http3_available()
+        assert result1 == result2
+
+
+class TestParseAltSvc:
+    """Tests for parse_alt_svc function."""
+
+    def test_parse_simple_h3(self):
+        """Test parsing simple h3 Alt-Svc."""
+        result = parse_alt_svc('h3=":443"')
+        assert "h3" in result
+        assert result["h3"] == ("", 443)
+
+    def test_parse_h3_with_host(self):
+        """Test parsing h3 with different host."""
+        result = parse_alt_svc('h3="alt.example.com:443"')
+        assert result["h3"] == ("alt.example.com", 443)
+
+    def test_parse_multiple_protocols(self):
+        """Test parsing multiple protocols."""
+        result = parse_alt_svc('h3=":443", h3-29=":443", h2=":443"')
+        assert "h3" in result
+        assert "h3-29" in result
+        assert "h2" in result
+
+    def test_parse_with_params(self):
+        """Test parsing with parameters (max-age, etc)."""
+        result = parse_alt_svc('h3=":443"; ma=86400')
+        assert result["h3"] == ("", 443)
+
+    def test_parse_clear(self):
+        """Test parsing 'clear' directive."""
+        result = parse_alt_svc("clear")
+        assert result == {}
+
+    def test_parse_empty(self):
+        """Test parsing empty string."""
+        result = parse_alt_svc("")
+        assert result == {}
+
+    def test_parse_custom_port(self):
+        """Test parsing with custom port."""
+        result = parse_alt_svc('h3=":8443"')
+        assert result["h3"] == ("", 8443)
+
+    def test_parse_host_without_port(self):
+        """Test parsing host without explicit port."""
+        result = parse_alt_svc('h3="alt.example.com"')
+        assert result["h3"] == ("alt.example.com", 443)
+
+    def test_parse_invalid_format_ignored(self):
+        """Test invalid format entries are ignored."""
+        result = parse_alt_svc('invalid, h3=":443"')
+        assert "h3" in result
+        assert "invalid" not in result
+
+    def test_parse_whitespace_handling(self):
+        """Test whitespace is handled correctly."""
+        result = parse_alt_svc('  h3=":443"  ,  h3-29=":443"  ')
+        assert "h3" in result
+        assert "h3-29" in result
+
+    def test_parse_cloudflare_style(self):
+        """Test parsing Cloudflare-style Alt-Svc header."""
+        header = 'h3=":443"; ma=86400, h3-29=":443"; ma=86400'
+        result = parse_alt_svc(header)
+        assert result["h3"] == ("", 443)
+        assert result["h3-29"] == ("", 443)
+
+    def test_parse_no_closing_quote(self):
+        """Test parsing when closing quote is missing."""
+        result = parse_alt_svc('h3=":443')
+        assert result["h3"] == ("", 443)
+
+    def test_parse_value_error_ignored(self):
+        """Test ValueError during parsing is ignored."""
+        result = parse_alt_svc('h3=":notaport", h3-29=":443"')
+        # h3 should be skipped due to ValueError, h3-29 should work
+        assert "h3-29" in result
+
+    def test_parse_index_error_ignored(self):
+        """Test IndexError during parsing is ignored."""
+        result = parse_alt_svc('=, h3=":443"')
+        assert "h3" in result
+
+
+class TestHttp3Module:
+    """Tests for HTTP3 module imports and errors."""
+
+    def test_http3_not_available_error_message(self):
+        """Test HTTP3NotAvailableError has helpful message."""
+        error = HTTP3NotAvailableError("test message")
+        assert "test message" in str(error)
+
+    @pytest.mark.skipif(
+        is_http3_available(),
+        reason="aioquic is installed"
+    )
+    def test_get_aioquic_raises_when_unavailable(self):
+        """Test _get_aioquic raises when aioquic not installed."""
+        with pytest.raises(HTTP3NotAvailableError, match="aioquic"):
+            _get_aioquic()
+
+    @pytest.mark.skipif(
+        not is_http3_available(),
+        reason="aioquic not installed"
+    )
+    def test_get_aioquic_returns_modules_when_available(self):
+        """Test _get_aioquic returns modules when aioquic installed."""
+        mods = _get_aioquic()
+        assert "quic_connect" in mods
+        assert "QuicConfiguration" in mods
+        assert "H3Connection" in mods
+
+
+class TestH3ResponseHandler:
+    """Tests for H3ResponseHandler class."""
+
+    def test_init(self):
+        """Test H3ResponseHandler initialization."""
+        handler = H3ResponseHandler(stream_id=1)
+
+        assert handler.stream_id == 1
+        assert handler.status_code == 0
+        assert handler.headers == []
+        assert handler.body == bytearray()
+        assert handler.complete is False
+        assert handler._waiter is None
+
+    def test_feed_event_headers_received(self):
+        """Test feeding HeadersReceived event."""
+        handler = H3ResponseHandler(stream_id=1)
+
+        mock_event = MagicMock()
+        mock_event.stream_id = 1
+        mock_event.headers = [
+            (b":status", b"200"),
+            (b"content-type", b"text/html"),
+        ]
+        mock_event.stream_ended = False
+
+        mods = {
+            "DataReceived": MagicMock,
+            "HeadersReceived": type(mock_event),
+        }
+
+        handler.feed_event(mock_event, mods)
+
+        assert handler.status_code == 200
+        assert ("content-type", "text/html") in handler.headers
+
+    def test_feed_event_headers_with_stream_ended(self):
+        """Test feeding HeadersReceived event with stream_ended=True."""
+        handler = H3ResponseHandler(stream_id=1)
+
+        mock_event = MagicMock()
+        mock_event.stream_id = 1
+        mock_event.headers = [(b":status", b"200")]
+        mock_event.stream_ended = True
+
+        mods = {
+            "DataReceived": MagicMock,
+            "HeadersReceived": type(mock_event),
+        }
+
+        handler.feed_event(mock_event, mods)
+
+        assert handler.complete is True
+
+    def test_feed_event_data_received(self):
+        """Test feeding DataReceived event."""
+        handler = H3ResponseHandler(stream_id=1)
+
+        # Create a class for DataReceived that isinstance can check
+        class MockDataReceived:
+            def __init__(self):
+                self.stream_id = 1
+                self.data = b"response body"
+                self.stream_ended = False
+
+        mock_event = MockDataReceived()
+
+        mods = {
+            "DataReceived": MockDataReceived,
+            "HeadersReceived": MagicMock,
+        }
+
+        handler.feed_event(mock_event, mods)
+
+        assert bytes(handler.body) == b"response body"
+        assert handler.complete is False
+
+    def test_feed_event_data_with_stream_ended(self):
+        """Test feeding DataReceived event with stream_ended=True."""
+        handler = H3ResponseHandler(stream_id=1)
+
+        mock_event = MagicMock()
+        mock_event.stream_id = 1
+        mock_event.data = b"body"
+        mock_event.stream_ended = True
+
+        mods = {
+            "DataReceived": type(mock_event),
+            "HeadersReceived": MagicMock,
+        }
+
+        handler.feed_event(mock_event, mods)
+
+        assert handler.complete is True
+
+    def test_feed_event_wrong_stream_id_ignored(self):
+        """Test feeding event with wrong stream_id is ignored."""
+        handler = H3ResponseHandler(stream_id=1)
+
+        mock_event = MagicMock()
+        mock_event.stream_id = 999  # Wrong stream ID
+        mock_event.data = b"data"
+        mock_event.stream_ended = False
+
+        mods = {
+            "DataReceived": type(mock_event),
+            "HeadersReceived": MagicMock,
+        }
+
+        handler.feed_event(mock_event, mods)
+
+        assert bytes(handler.body) == b""
+
+    def test_feed_event_string_headers(self):
+        """Test feeding HeadersReceived event with string headers."""
+        handler = H3ResponseHandler(stream_id=1)
+
+        mock_event = MagicMock()
+        mock_event.stream_id = 1
+        mock_event.headers = [
+            (":status", "200"),  # String headers
+            ("content-type", "text/html"),
+        ]
+        mock_event.stream_ended = False
+
+        mods = {
+            "DataReceived": MagicMock,
+            "HeadersReceived": type(mock_event),
+        }
+
+        handler.feed_event(mock_event, mods)
+
+        assert handler.status_code == 200
+
+    def test_feed_event_filters_pseudo_headers(self):
+        """Test pseudo-headers (starting with :) are filtered."""
+        handler = H3ResponseHandler(stream_id=1)
+
+        mock_event = MagicMock()
+        mock_event.stream_id = 1
+        mock_event.headers = [
+            (b":status", b"200"),
+            (b":other", b"value"),
+            (b"content-type", b"text/html"),
+        ]
+        mock_event.stream_ended = False
+
+        mods = {
+            "DataReceived": MagicMock,
+            "HeadersReceived": type(mock_event),
+        }
+
+        handler.feed_event(mock_event, mods)
+
+        header_names = [name for name, _ in handler.headers]
+        assert ":status" not in header_names
+        assert ":other" not in header_names
+        assert "content-type" in header_names
+
+    @pytest.mark.asyncio
+    async def test_wait_complete_already_complete(self):
+        """Test wait_complete returns immediately if already complete."""
+        handler = H3ResponseHandler(stream_id=1)
+        handler.complete = True
+
+        # Should return immediately without waiting
+        await handler.wait_complete(timeout=1.0)
+
+    @pytest.mark.asyncio
+    async def test_wait_complete_timeout(self):
+        """Test wait_complete raises on timeout."""
+        handler = H3ResponseHandler(stream_id=1)
+
+        with pytest.raises(ProtocolError, match="HTTP/3 response timeout"):
+            await handler.wait_complete(timeout=0.01)
+
+    def test_mark_complete_sets_waiter(self):
+        """Test _mark_complete sets waiter result."""
+        import asyncio
+        handler = H3ResponseHandler(stream_id=1)
+        handler._waiter = asyncio.get_event_loop().create_future()
+
+        handler._mark_complete()
+
+        assert handler.complete is True
+        assert handler._waiter.done()
+
+
+class TestHTTP3Protocol:
+    """Tests for HTTP3Protocol class."""
+
+    def test_init(self):
+        """Test HTTP3Protocol initialization."""
+        proto = HTTP3Protocol(
+            host="example.com",
+            port=443,
+            verify=True,
+            timeout=30.0,
+            profile={"http3": {"max_stream_data": 1048576}},
+        )
+
+        assert proto.host == "example.com"
+        assert proto.port == 443
+        assert proto.verify is True
+        assert proto.timeout == 30.0
+        assert proto._connected is False
+
+    def test_init_default_values(self):
+        """Test HTTP3Protocol default values."""
+        proto = HTTP3Protocol(host="example.com")
+
+        assert proto.port == 443
+        assert proto.verify is True
+        assert proto.timeout == 10.0
+        assert proto.profile == {}
+
+    @pytest.mark.asyncio
+    async def test_close(self):
+        """Test HTTP3Protocol close."""
+        proto = HTTP3Protocol(host="example.com")
+        proto._connected = True
+        proto._protocol = MagicMock()
+        proto._h3 = MagicMock()
+        proto._handlers = {1: MagicMock()}
+
+        await proto.close()
+
+        assert proto._connected is False
+        assert proto._h3 is None
+        assert proto._protocol is None
+        assert len(proto._handlers) == 0
+
+    @pytest.mark.asyncio
+    async def test_close_with_protocol_error(self):
+        """Test close handles protocol close error gracefully."""
+        proto = HTTP3Protocol(host="example.com")
+        proto._connected = True
+        proto._protocol = MagicMock()
+        proto._protocol.close.side_effect = Exception("close error")
+
+        await proto.close()  # Should not raise
+
+        assert proto._connected is False
+
+    @pytest.mark.skipif(
+        not is_http3_available(),
+        reason="aioquic not installed"
+    )
+    @pytest.mark.asyncio
+    async def test_connect_timeout(self):
+        """Test connect raises on timeout."""
+        proto = HTTP3Protocol(
+            host="nonexistent.example.com",
+            port=443,
+            timeout=0.01,
+        )
+
+        with pytest.raises(ProtocolError, match="HTTP/3 connection"):
+            await proto.connect()
+
+    @pytest.mark.skipif(
+        is_http3_available(),
+        reason="aioquic is installed"
+    )
+    @pytest.mark.asyncio
+    async def test_connect_without_aioquic(self):
+        """Test connect raises when aioquic not installed."""
+        proto = HTTP3Protocol(host="example.com")
+
+        with pytest.raises(HTTP3NotAvailableError):
+            await proto.connect()
+
+
+class TestHTTP3Request:
+    """Tests for http3_request function."""
+
+    @pytest.mark.skipif(
+        is_http3_available(),
+        reason="aioquic is installed - test for unavailable case"
+    )
+    @pytest.mark.asyncio
+    async def test_http3_request_without_aioquic(self):
+        """Test http3_request raises when aioquic not installed."""
+        from gakido.http3 import http3_request
+
+        with pytest.raises(HTTP3NotAvailableError):
+            await http3_request(
+                method="GET",
+                url="https://example.com",
+                host="example.com",
+                port=443,
+                path="/",
+                headers=[],
+            )
+
+
+class TestHTTP3ProtocolRequest:
+    """Tests for HTTP3Protocol.request method."""
+
+    @pytest.mark.asyncio
+    async def test_request_reconnects_if_disconnected(self):
+        """Test request calls connect if not connected."""
+        proto = HTTP3Protocol(host="example.com")
+        proto._connected = False
+        proto.connect = AsyncMock(side_effect=ProtocolError("connection failed"))
+
+        with pytest.raises(ProtocolError, match="connection failed"):
+            await proto.request("GET", "/", [])

--- a/tests/test_ja3.py
+++ b/tests/test_ja3.py
@@ -1,0 +1,182 @@
+"""Tests for gakido.impersonation.ja3 module."""
+
+import pytest
+from gakido.impersonation.ja3 import (
+    apply_ja3_overrides,
+    apply_tls_configuration_options,
+    SIGNATURES,
+)
+from gakido.fingerprints import ExtraFingerprints
+
+
+class TestApplyJa3Overrides:
+    """Tests for apply_ja3_overrides function."""
+
+    def test_no_overrides_returns_unchanged(self):
+        """Test empty ja3 dict returns profile unchanged."""
+        profile = {"tls": {"alpn": ["h2"]}}
+        result = apply_ja3_overrides(profile, None)
+        assert result == profile
+
+    def test_empty_dict_returns_unchanged(self):
+        """Test empty ja3 dict returns profile unchanged."""
+        profile = {"tls": {"alpn": ["h2"]}}
+        result = apply_ja3_overrides(profile, {})
+        assert result == profile
+
+    def test_override_ciphers(self):
+        """Test overriding ciphers."""
+        profile = {}
+        ja3 = {"ciphers": ["TLS_AES_128_GCM_SHA256"]}
+        result = apply_ja3_overrides(profile, ja3)
+        assert result["tls"]["ciphers"] == ["TLS_AES_128_GCM_SHA256"]
+
+    def test_override_alpn(self):
+        """Test overriding ALPN protocols."""
+        profile = {}
+        ja3 = {"alpn": ["h2", "http/1.1"]}
+        result = apply_ja3_overrides(profile, ja3)
+        assert result["tls"]["alpn"] == ["h2", "http/1.1"]
+        # Also mirrored to http2
+        assert result["http2"]["alpn"] == ["h2", "http/1.1"]
+
+    def test_override_curves(self):
+        """Test overriding elliptic curves."""
+        profile = {}
+        ja3 = {"curves": ["X25519", "prime256v1"]}
+        result = apply_ja3_overrides(profile, ja3)
+        assert result["tls"]["curves"] == ["X25519", "prime256v1"]
+
+    def test_override_sig_algs(self):
+        """Test overriding signature algorithms."""
+        profile = {}
+        ja3 = {"sig_algs": ["ecdsa_secp256r1_sha256"]}
+        result = apply_ja3_overrides(profile, ja3)
+        assert result["tls"]["sig_algs"] == ["ecdsa_secp256r1_sha256"]
+
+    def test_override_multiple(self):
+        """Test overriding multiple fields."""
+        profile = {}
+        ja3 = {
+            "ciphers": ["cipher1"],
+            "alpn": ["h2"],
+            "curves": ["X25519"],
+        }
+        result = apply_ja3_overrides(profile, ja3)
+        assert result["tls"]["ciphers"] == ["cipher1"]
+        assert result["tls"]["alpn"] == ["h2"]
+        assert result["tls"]["curves"] == ["X25519"]
+
+    def test_override_preserves_existing_profile(self):
+        """Test overriding preserves other profile fields."""
+        profile = {"headers": {"default": [("User-Agent", "test")]}}
+        ja3 = {"alpn": ["h2"]}
+        result = apply_ja3_overrides(profile, ja3)
+        assert result["headers"]["default"] == [("User-Agent", "test")]
+
+    def test_override_replaces_existing_tls(self):
+        """Test overriding replaces existing TLS values."""
+        profile = {"tls": {"alpn": ["http/1.1"]}}
+        ja3 = {"alpn": ["h2"]}
+        result = apply_ja3_overrides(profile, ja3)
+        assert result["tls"]["alpn"] == ["h2"]
+
+    def test_empty_override_value_ignored(self):
+        """Test empty override values are ignored."""
+        profile = {"tls": {"alpn": ["h2"]}}
+        ja3 = {"alpn": [], "ciphers": None}
+        result = apply_ja3_overrides(profile, ja3)
+        assert result["tls"]["alpn"] == ["h2"]
+
+    def test_signatures_constant(self):
+        """Test SIGNATURES constant contains expected keys."""
+        assert "ciphers" in SIGNATURES
+        assert "alpn" in SIGNATURES
+        assert "curves" in SIGNATURES
+        assert "sig_algs" in SIGNATURES
+
+
+class TestApplyTlsConfigurationOptions:
+    """Tests for apply_tls_configuration_options function."""
+
+    def test_no_options_returns_unchanged(self):
+        """Test None options returns profile unchanged."""
+        profile = {"tls": {"alpn": ["h2"]}}
+        result = apply_tls_configuration_options(profile, None)
+        assert result == profile
+
+    def test_empty_options_returns_unchanged(self):
+        """Test empty options returns profile unchanged."""
+        profile = {"tls": {"alpn": ["h2"]}}
+        result = apply_tls_configuration_options(profile, {})
+        assert result == profile
+
+    def test_ja3_str_stored(self):
+        """Test ja3_str is stored on profile."""
+        profile = {}
+        opts = {"ja3_str": "771,4866-4867,0-11-10,29,0"}
+        result = apply_tls_configuration_options(profile, opts)
+        assert result["ja3_str"] == "771,4866-4867,0-11-10,29,0"
+
+    def test_akamai_str_stored(self):
+        """Test akamai_str is stored on profile."""
+        profile = {}
+        opts = {"akamai_str": "1:65536;3:1000"}
+        result = apply_tls_configuration_options(profile, opts)
+        assert result["akamai_str"] == "1:65536;3:1000"
+
+    def test_extra_fp_stored(self):
+        """Test extra_fp is stored on profile."""
+        profile = {}
+        extra_fp = ExtraFingerprints(alpn=["h2"])
+        opts = {"extra_fp": extra_fp}
+        result = apply_tls_configuration_options(profile, opts)
+        assert result["extra_fp"] is extra_fp
+
+    def test_extra_fp_alpn_applied(self):
+        """Test extra_fp ALPN is applied to profile."""
+        profile = {}
+        extra_fp = ExtraFingerprints(alpn=["h2", "http/1.1"])
+        opts = {"extra_fp": extra_fp}
+        result = apply_tls_configuration_options(profile, opts)
+        assert result["tls"]["alpn"] == ["h2", "http/1.1"]
+        assert result["http2"]["alpn"] == ["h2", "http/1.1"]
+
+    def test_extra_fp_ciphers_applied(self):
+        """Test extra_fp ciphers are applied to profile."""
+        profile = {}
+        extra_fp = ExtraFingerprints(ciphers=["cipher1", "cipher2"])
+        opts = {"extra_fp": extra_fp}
+        result = apply_tls_configuration_options(profile, opts)
+        assert result["tls"]["ciphers"] == "cipher1:cipher2"
+
+    def test_extra_fp_curves_applied(self):
+        """Test extra_fp curves are applied to profile."""
+        profile = {}
+        extra_fp = ExtraFingerprints(curves=["X25519"])
+        opts = {"extra_fp": extra_fp}
+        result = apply_tls_configuration_options(profile, opts)
+        assert result["tls"]["curves"] == ["X25519"]
+
+    def test_extra_fp_sig_algs_applied(self):
+        """Test extra_fp sig_algs are applied to profile."""
+        profile = {}
+        extra_fp = ExtraFingerprints(sig_algs=["ecdsa_secp256r1_sha256"])
+        opts = {"extra_fp": extra_fp}
+        result = apply_tls_configuration_options(profile, opts)
+        assert result["tls"]["sig_algs"] == ["ecdsa_secp256r1_sha256"]
+
+    def test_extra_fp_empty_values_not_applied(self):
+        """Test extra_fp with empty values doesn't add empty entries."""
+        profile = {}
+        extra_fp = ExtraFingerprints()  # All empty
+        opts = {"extra_fp": extra_fp}
+        result = apply_tls_configuration_options(profile, opts)
+        assert "tls" not in result or "alpn" not in result.get("tls", {})
+
+    def test_preserves_existing_profile(self):
+        """Test options preserve existing profile fields."""
+        profile = {"headers": {"default": []}}
+        opts = {"ja3_str": "test"}
+        result = apply_tls_configuration_options(profile, opts)
+        assert result["headers"]["default"] == []

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,111 @@
+"""Tests for gakido.models module."""
+
+import json
+import pytest
+from gakido.models import Response
+
+
+class TestResponse:
+    """Tests for the Response class."""
+
+    def test_response_basic_attributes(self):
+        """Test basic response attributes."""
+        resp = Response(
+            status_code=200,
+            reason="OK",
+            http_version="1.1",
+            headers=[("Content-Type", "text/html")],
+            body=b"Hello World",
+        )
+        assert resp.status_code == 200
+        assert resp.reason == "OK"
+        assert resp.http_version == "1.1"
+        assert resp.content == b"Hello World"
+
+    def test_response_headers_case_insensitive(self):
+        """Test headers dict is case-insensitive."""
+        resp = Response(
+            200, "OK", "1.1",
+            headers=[("Content-Type", "text/html"), ("X-Custom-Header", "value")],
+            body=b"",
+        )
+        assert resp.headers["content-type"] == "text/html"
+        assert resp.headers["x-custom-header"] == "value"
+
+    def test_response_headers_last_write_wins(self):
+        """Test that duplicate headers use last value."""
+        resp = Response(
+            200, "OK", "1.1",
+            headers=[("X-Header", "first"), ("X-Header", "second")],
+            body=b"",
+        )
+        assert resp.headers["x-header"] == "second"
+
+    def test_response_raw_headers_preserved(self):
+        """Test raw_headers preserves original order and case."""
+        headers = [("Content-Type", "text/html"), ("X-Custom", "value")]
+        resp = Response(200, "OK", "1.1", headers=headers, body=b"")
+        assert resp.raw_headers == headers
+
+    def test_response_text_default_utf8(self):
+        """Test text property defaults to UTF-8."""
+        resp = Response(200, "OK", "1.1", headers=[], body=b"Hello")
+        assert resp.text == "Hello"
+
+    def test_response_text_with_charset(self):
+        """Test text property respects charset in content-type."""
+        resp = Response(
+            200, "OK", "1.1",
+            headers=[("Content-Type", "text/html; charset=latin-1")],
+            body="Hëllo".encode("latin-1"),
+        )
+        assert resp.text == "Hëllo"
+
+    def test_response_text_invalid_charset_fallback(self):
+        """Test text falls back to UTF-8 for invalid charset."""
+        resp = Response(
+            200, "OK", "1.1",
+            headers=[("Content-Type", "text/html; charset=invalid-charset")],
+            body=b"Hello",
+        )
+        assert resp.text == "Hello"
+
+    def test_response_text_decodes_with_errors_replace(self):
+        """Test text handles invalid bytes gracefully."""
+        resp = Response(200, "OK", "1.1", headers=[], body=b"\xff\xfe")
+        # Should not raise, uses errors="replace"
+        assert isinstance(resp.text, str)
+
+    def test_response_json(self):
+        """Test json method parses JSON body."""
+        data = {"key": "value", "number": 42}
+        resp = Response(
+            200, "OK", "1.1",
+            headers=[("Content-Type", "application/json")],
+            body=json.dumps(data).encode(),
+        )
+        assert resp.json() == data
+
+    def test_response_json_invalid_raises(self):
+        """Test json method raises on invalid JSON."""
+        resp = Response(200, "OK", "1.1", headers=[], body=b"not json")
+        with pytest.raises(json.JSONDecodeError):
+            resp.json()
+
+    def test_response_repr(self):
+        """Test response repr format."""
+        resp = Response(200, "OK", "1.1", headers=[], body=b"12345")
+        assert repr(resp) == "<Response [200] 5 bytes>"
+
+    def test_response_empty_body(self):
+        """Test response with empty body."""
+        resp = Response(204, "No Content", "1.1", headers=[], body=b"")
+        assert resp.content == b""
+        assert resp.text == ""
+
+    def test_response_content_property(self):
+        """Test content property returns body bytes."""
+        body = b"\x00\x01\x02\x03"
+        resp = Response(200, "OK", "1.1", headers=[], body=body)
+        assert resp.content == body
+        assert isinstance(resp.content, bytes)

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -1,0 +1,138 @@
+"""Tests for gakido.multipart module."""
+
+import pytest
+from gakido.multipart import build_multipart, _encode_field, _encode_file
+
+
+class TestEncodeField:
+    """Tests for _encode_field helper."""
+
+    def test_encode_simple_field(self):
+        """Test encoding a simple form field."""
+        result = _encode_field("name", "John")
+        assert b'Content-Disposition: form-data; name="name"' in result
+        assert b"John" in result
+        assert result.endswith(b"\r\n")
+
+    def test_encode_field_with_special_chars(self):
+        """Test encoding field with special characters in value."""
+        result = _encode_field("message", "Hello & World!")
+        assert b"Hello & World!" in result
+
+
+class TestEncodeFile:
+    """Tests for _encode_file helper."""
+
+    def test_encode_file_basic(self):
+        """Test encoding a file."""
+        result = _encode_file("upload", "test.txt", b"content", "text/plain")
+        assert b'Content-Disposition: form-data; name="upload"; filename="test.txt"' in result
+        assert b"Content-Type: text/plain" in result
+        assert b"content" in result
+
+    def test_encode_file_default_content_type(self):
+        """Test encoding file with no content type uses octet-stream."""
+        result = _encode_file("file", "data.bin", b"\x00\x01", None)
+        assert b"Content-Type: application/octet-stream" in result
+
+    def test_encode_file_binary_content(self):
+        """Test encoding file with binary content."""
+        binary = bytes(range(256))
+        result = _encode_file("binary", "data.bin", binary, None)
+        assert binary in result
+
+
+class TestBuildMultipart:
+    """Tests for build_multipart function."""
+
+    def test_build_with_only_files(self):
+        """Test building multipart with only files."""
+        files = {"doc": b"file content"}
+        content_type, body = build_multipart(None, files)
+
+        assert content_type.startswith("multipart/form-data; boundary=")
+        assert b"file content" in body
+        assert b'name="doc"' in body
+
+    def test_build_with_data_and_files(self):
+        """Test building multipart with both data and files."""
+        data = {"field1": "value1", "field2": "value2"}
+        files = {"upload": b"file content"}
+        content_type, body = build_multipart(data, files)
+
+        assert b"value1" in body
+        assert b"value2" in body
+        assert b"file content" in body
+        assert content_type.startswith("multipart/form-data; boundary=")
+
+    def test_build_with_file_tuple(self):
+        """Test building multipart with file as (filename, content, type) tuple."""
+        files = {"doc": ("report.pdf", b"PDF content", "application/pdf")}
+        content_type, body = build_multipart(None, files)
+
+        assert b'filename="report.pdf"' in body
+        assert b"Content-Type: application/pdf" in body
+        assert b"PDF content" in body
+
+    def test_build_with_file_tuple_no_content_type(self):
+        """Test file tuple with None content type."""
+        files = {"doc": ("file.bin", b"binary", None)}
+        content_type, body = build_multipart(None, files)
+
+        assert b"Content-Type: application/octet-stream" in body
+
+    def test_boundary_is_unique(self):
+        """Test each call generates unique boundary."""
+        files = {"f": b"content"}
+        ct1, _ = build_multipart(None, files)
+        ct2, _ = build_multipart(None, files)
+
+        # Extract boundaries
+        b1 = ct1.split("boundary=")[1]
+        b2 = ct2.split("boundary=")[1]
+        assert b1 != b2
+
+    def test_body_ends_with_closing_boundary(self):
+        """Test body ends with closing boundary."""
+        files = {"f": b"content"}
+        content_type, body = build_multipart(None, files)
+
+        boundary = content_type.split("boundary=")[1]
+        assert body.endswith(f"--{boundary}--\r\n".encode())
+
+    def test_multiple_files(self):
+        """Test building multipart with multiple files."""
+        files = {
+            "file1": b"content1",
+            "file2": ("name2.txt", b"content2", "text/plain"),
+            "file3": b"content3",
+        }
+        content_type, body = build_multipart(None, files)
+
+        assert b"content1" in body
+        assert b"content2" in body
+        assert b"content3" in body
+        assert b'name="file1"' in body
+        assert b'name="file2"' in body
+        assert b'name="file3"' in body
+
+    def test_empty_files_dict(self):
+        """Test building with empty files dict."""
+        content_type, body = build_multipart(None, {})
+        # Should still have closing boundary
+        assert b"--" in body
+
+    def test_data_only_no_files(self):
+        """Test building with data only (files required but can be empty)."""
+        data = {"key": "value"}
+        content_type, body = build_multipart(data, {})
+
+        # Data fields should be included
+        assert b"value" in body
+
+    def test_special_characters_in_filename(self):
+        """Test filename with special characters."""
+        files = {"f": ("file name.txt", b"content", "text/plain")}
+        content_type, body = build_multipart(None, files)
+
+        assert b'filename="file name.txt"' in body

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -1,0 +1,165 @@
+"""Tests for gakido.pool module."""
+
+import pytest
+from unittest.mock import Mock, patch
+from gakido.pool import ConnectionPool
+
+
+class TestConnectionPool:
+    """Tests for ConnectionPool class."""
+
+    def test_init_defaults(self):
+        """Test pool initialization with defaults."""
+        pool = ConnectionPool(profile={})
+        assert pool.timeout == 10.0
+        assert pool.verify is True
+        assert pool.max_per_host == 4
+
+    def test_init_custom_values(self):
+        """Test pool initialization with custom values."""
+        pool = ConnectionPool(
+            profile={"tls": {}},
+            timeout=30.0,
+            verify=False,
+            max_per_host=8,
+        )
+        assert pool.timeout == 30.0
+        assert pool.verify is False
+        assert pool.max_per_host == 8
+
+    def test_acquire_creates_new_connection(self):
+        """Test acquire creates new connection when pool empty."""
+        pool = ConnectionPool(profile={})
+        conn = pool.acquire("https", "example.com", 443)
+
+        assert conn.host == "example.com"
+        assert conn.port == 443
+        assert conn.scheme == "https"
+
+    def test_release_and_reuse(self):
+        """Test released connection can be reused."""
+        pool = ConnectionPool(profile={})
+        conn1 = pool.acquire("https", "example.com", 443)
+        conn1.closed = False  # Simulate open connection
+
+        pool.release(conn1)
+        conn2 = pool.acquire("https", "example.com", 443)
+
+        assert conn1 is conn2
+
+    def test_release_closed_connection_ignored(self):
+        """Test releasing closed connection doesn't add to pool."""
+        pool = ConnectionPool(profile={})
+        conn = pool.acquire("https", "example.com", 443)
+        conn.closed = True
+
+        pool.release(conn)
+
+        # Should create new connection
+        conn2 = pool.acquire("https", "example.com", 443)
+        assert conn is not conn2
+
+    def test_max_per_host_limit(self):
+        """Test max_per_host limit is respected."""
+        pool = ConnectionPool(profile={}, max_per_host=2)
+
+        # Create and release max connections
+        conns = []
+        for _ in range(3):
+            conn = pool.acquire("https", "example.com", 443)
+            conn.closed = False
+            conns.append(conn)
+
+        # Release all
+        for conn in conns:
+            pool.release(conn)
+
+        # Only max_per_host should be kept
+        key = ("https", "example.com", 443)
+        assert len(pool._pools[key]) == 2
+
+    def test_different_hosts_separate_pools(self):
+        """Test different hosts use separate pools."""
+        pool = ConnectionPool(profile={})
+
+        conn1 = pool.acquire("https", "example.com", 443)
+        conn2 = pool.acquire("https", "other.com", 443)
+
+        assert conn1.host == "example.com"
+        assert conn2.host == "other.com"
+
+    def test_different_ports_separate_pools(self):
+        """Test different ports use separate pools."""
+        pool = ConnectionPool(profile={})
+
+        conn1 = pool.acquire("https", "example.com", 443)
+        conn2 = pool.acquire("https", "example.com", 8443)
+
+        assert conn1.port == 443
+        assert conn2.port == 8443
+
+    def test_different_schemes_separate_pools(self):
+        """Test different schemes use separate pools."""
+        pool = ConnectionPool(profile={})
+
+        conn1 = pool.acquire("http", "example.com", 80)
+        conn2 = pool.acquire("https", "example.com", 443)
+
+        assert conn1.scheme == "http"
+        assert conn2.scheme == "https"
+
+    def test_close_closes_all_connections(self):
+        """Test close() closes all pooled connections."""
+        pool = ConnectionPool(profile={})
+
+        # Acquire and release some connections
+        conn1 = pool.acquire("https", "example.com", 443)
+        conn1.closed = False
+        pool.release(conn1)
+
+        conn2 = pool.acquire("https", "other.com", 443)
+        conn2.closed = False
+        pool.release(conn2)
+
+        # Close pool
+        with patch.object(conn1, 'close') as mock_close1, \
+             patch.object(conn2, 'close') as mock_close2:
+            pool.close()
+            mock_close1.assert_called_once()
+            mock_close2.assert_called_once()
+
+        assert len(pool._pools) == 0
+
+    def test_acquire_skips_closed_connections(self):
+        """Test acquire skips closed connections in pool."""
+        pool = ConnectionPool(profile={})
+
+        # Create and release connection, then mark it closed
+        conn1 = pool.acquire("https", "example.com", 443)
+        conn1.closed = False
+        pool.release(conn1)
+        conn1.closed = True  # Mark as closed after release
+
+        # Should create new connection
+        conn2 = pool.acquire("https", "example.com", 443)
+        assert conn1 is not conn2
+
+    def test_profile_passed_to_connection(self):
+        """Test profile is passed to created connections."""
+        profile = {"tls": {"alpn": ["h2"]}}
+        pool = ConnectionPool(profile=profile)
+
+        conn = pool.acquire("https", "example.com", 443)
+        assert conn.profile == profile
+
+    def test_timeout_passed_to_connection(self):
+        """Test timeout is passed to created connections."""
+        pool = ConnectionPool(profile={}, timeout=30.0)
+        conn = pool.acquire("https", "example.com", 443)
+        assert conn.timeout == 30.0
+
+    def test_verify_passed_to_connection(self):
+        """Test verify is passed to created connections."""
+        pool = ConnectionPool(profile={}, verify=False)
+        conn = pool.acquire("https", "example.com", 443)
+        assert conn.verify is False

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -1,7 +1,137 @@
+"""Tests for gakido.impersonation.profiles module."""
+
+import pytest
 from gakido.impersonation import PROFILES, get_profile
+from gakido.impersonation.profiles import ALIAS_MAP
 
 
-def test_get_profile_returns_copy():
-    profile = get_profile("chrome_120")
-    profile["headers"]["default"][0] = ("User-Agent", "modified")
-    assert PROFILES["chrome_120"]["headers"]["default"][0][0] == "Connection"
+class TestProfiles:
+    """Tests for profile definitions."""
+
+    def test_get_profile_returns_copy(self):
+        """Test get_profile returns a deep copy."""
+        profile = get_profile("chrome_120")
+        profile["headers"]["default"][0] = ("User-Agent", "modified")
+        # Original should be unchanged
+        assert PROFILES["chrome_120"]["headers"]["default"][0][0] == "Connection"
+
+    def test_get_profile_unknown_raises(self):
+        """Test get_profile raises for unknown profile."""
+        with pytest.raises(KeyError, match="Unknown impersonation profile"):
+            get_profile("unknown_browser_999")
+
+    def test_chrome_120_profile_exists(self):
+        """Test chrome_120 profile exists and has required fields."""
+        profile = get_profile("chrome_120")
+        assert "tls" in profile
+        assert "http2" in profile
+        assert "headers" in profile
+
+    def test_firefox_120_profile_exists(self):
+        """Test firefox_120 profile exists."""
+        profile = get_profile("firefox_120")
+        assert "tls" in profile
+        assert "headers" in profile
+
+    def test_safari_170_profile_exists(self):
+        """Test safari_170 profile exists."""
+        profile = get_profile("safari_170")
+        assert "tls" in profile
+
+    def test_profile_has_tls_config(self):
+        """Test profiles have TLS configuration."""
+        for name in ["chrome_120", "firefox_120", "safari_170"]:
+            profile = get_profile(name)
+            tls = profile.get("tls", {})
+            assert "ciphers" in tls or "alpn" in tls
+
+    def test_profile_has_default_headers(self):
+        """Test profiles have default headers."""
+        for name in ["chrome_120", "firefox_120"]:
+            profile = get_profile(name)
+            headers = profile.get("headers", {})
+            assert "default" in headers
+            assert len(headers["default"]) > 0
+
+    def test_profile_has_header_order(self):
+        """Test profiles have header order."""
+        for name in ["chrome_120", "firefox_120"]:
+            profile = get_profile(name)
+            headers = profile.get("headers", {})
+            assert "order" in headers
+
+    def test_profile_has_http3_config(self):
+        """Test modern profiles have HTTP/3 config."""
+        for name in ["chrome_120", "firefox_120", "safari_170"]:
+            profile = get_profile(name)
+            assert "http3" in profile
+            h3 = profile["http3"]
+            assert "max_stream_data" in h3
+            assert "max_data" in h3
+
+    def test_alias_map_resolves(self):
+        """Test alias map entries resolve to base profiles."""
+        for alias, target in ALIAS_MAP.items():
+            assert target in PROFILES
+
+    def test_aliases_accessible_via_get_profile(self):
+        """Test aliases work with get_profile."""
+        # Test a few aliases
+        aliases = ["chrome99", "firefox133", "safari153"]
+        for alias in aliases:
+            if alias in ALIAS_MAP:
+                profile = get_profile(alias)
+                assert profile is not None
+
+    def test_chrome_user_agent(self):
+        """Test Chrome profile has Chrome user agent."""
+        profile = get_profile("chrome_120")
+        ua = None
+        for name, value in profile["headers"]["default"]:
+            if name.lower() == "user-agent":
+                ua = value
+                break
+        assert ua is not None
+        assert "Chrome" in ua
+
+    def test_firefox_user_agent(self):
+        """Test Firefox profile has Firefox user agent."""
+        profile = get_profile("firefox_120")
+        ua = None
+        for name, value in profile["headers"]["default"]:
+            if name.lower() == "user-agent":
+                ua = value
+                break
+        assert ua is not None
+        assert "Firefox" in ua
+
+    def test_profile_alpn_values(self):
+        """Test profile ALPN values are valid."""
+        valid_alpn = {"h2", "http/1.1", "h3"}
+        for name in ["chrome_120", "firefox_120"]:
+            profile = get_profile(name)
+            alpn = profile.get("tls", {}).get("alpn", [])
+            for protocol in alpn:
+                assert protocol in valid_alpn
+
+    def test_derived_profiles_have_base_config(self):
+        """Test derived profiles inherit base config."""
+        # chrome_120_android should have same TLS as chrome_120
+        base = get_profile("chrome_120")
+        derived = get_profile("chrome_120_android")
+        assert derived["tls"] == base["tls"]
+
+    def test_ios_profiles_have_mobile_user_agent(self):
+        """Test iOS profiles have mobile user agent."""
+        profile = get_profile("safari_170_ios")
+        ua = None
+        for name, value in profile["headers"]["default"]:
+            if name.lower() == "user-agent":
+                ua = value
+                break
+        assert "iPhone" in ua or "Mobile" in ua
+
+    def test_all_profiles_in_profiles_dict(self):
+        """Test all aliases are materialized in PROFILES."""
+        for alias in ALIAS_MAP:
+            assert alias in PROFILES

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -1,0 +1,73 @@
+"""Tests for gakido.proxy module."""
+
+import pytest
+from gakido.proxy import ProxyRotator
+
+
+class TestProxyRotator:
+    """Tests for ProxyRotator class."""
+
+    def test_init_with_list(self):
+        """Test initialization with list of proxies."""
+        proxies = ["http://proxy1:8080", "http://proxy2:8080"]
+        rotator = ProxyRotator(proxies)
+        assert rotator.proxies == proxies
+
+    def test_init_with_tuple(self):
+        """Test initialization with tuple of proxies."""
+        proxies = ("http://proxy1:8080", "http://proxy2:8080")
+        rotator = ProxyRotator(proxies)
+        assert rotator.proxies == list(proxies)
+
+    def test_init_with_generator(self):
+        """Test initialization with generator."""
+        def gen():
+            yield "http://proxy1:8080"
+            yield "http://proxy2:8080"
+
+        rotator = ProxyRotator(gen())
+        assert len(rotator.proxies) == 2
+
+    def test_init_empty_list(self):
+        """Test initialization with empty list."""
+        rotator = ProxyRotator([])
+        assert rotator.proxies == []
+
+    def test_next_returns_proxy(self):
+        """Test next() returns a proxy from the list."""
+        proxies = ["http://proxy1:8080", "http://proxy2:8080"]
+        rotator = ProxyRotator(proxies)
+
+        result = rotator.next()
+        assert result in proxies
+
+    def test_next_empty_returns_none(self):
+        """Test next() returns None when no proxies."""
+        rotator = ProxyRotator([])
+        assert rotator.next() is None
+
+    def test_next_single_proxy(self):
+        """Test next() with single proxy always returns it."""
+        rotator = ProxyRotator(["http://proxy:8080"])
+
+        for _ in range(10):
+            assert rotator.next() == "http://proxy:8080"
+
+    def test_next_random_selection(self):
+        """Test next() randomly selects from proxies."""
+        proxies = [f"http://proxy{i}:8080" for i in range(10)]
+        rotator = ProxyRotator(proxies)
+
+        # With many proxies and many calls, we should see variety
+        results = {rotator.next() for _ in range(100)}
+        # Should have selected multiple different proxies
+        assert len(results) > 1
+
+    def test_proxies_list_is_copy(self):
+        """Test internal list is a copy of input."""
+        original = ["http://proxy:8080"]
+        rotator = ProxyRotator(original)
+
+        # Modifying original shouldn't affect rotator
+        original.append("http://proxy2:8080")
+        assert len(rotator.proxies) == 1

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,0 +1,168 @@
+"""Tests for gakido.session module."""
+
+import pytest
+from unittest.mock import Mock, patch, MagicMock
+from gakido.session import Session
+from gakido.models import Response
+
+
+class TestSession:
+    """Tests for Session class."""
+
+    @patch('gakido.session.Client')
+    def test_session_creates_client(self, mock_client_class):
+        """Test Session creates a Client instance."""
+        Session(impersonate="chrome_120")
+        mock_client_class.assert_called_once_with(impersonate="chrome_120")
+
+    @patch('gakido.session.Client')
+    def test_session_passes_kwargs_to_client(self, mock_client_class):
+        """Test Session passes kwargs to Client."""
+        Session(impersonate="firefox_133", timeout=30.0, verify=False)
+        mock_client_class.assert_called_once_with(
+            impersonate="firefox_133",
+            timeout=30.0,
+            verify=False
+        )
+
+    @patch('gakido.session.Client')
+    def test_session_has_cookie_jar(self, mock_client_class):
+        """Test Session has a CookieJar."""
+        session = Session()
+        assert session.cookies is not None
+
+    @patch('gakido.session.Client')
+    def test_request_attaches_cookies(self, mock_client_class):
+        """Test request attaches cookies from jar."""
+        mock_client = MagicMock()
+        mock_response = Response(
+            200, "OK", "1.1",
+            headers=[],
+            body=b"",
+        )
+        mock_client.request.return_value = mock_response
+        mock_client_class.return_value = mock_client
+
+        session = Session()
+        # Pre-set a cookie
+        session.cookies.store["example.com"] = {"session": "abc123"}
+
+        session.request("GET", "https://example.com/path")
+
+        # Check Cookie header was added
+        call_args = mock_client.request.call_args
+        headers = call_args.kwargs.get("headers", {}) or call_args[1].get("headers", {})
+        assert "Cookie" in headers or any("Cookie" in str(h) for h in [headers])
+
+    @patch('gakido.session.Client')
+    def test_request_captures_set_cookie(self, mock_client_class):
+        """Test request captures Set-Cookie from response."""
+        mock_client = MagicMock()
+        mock_response = Response(
+            200, "OK", "1.1",
+            headers=[("Set-Cookie", "token=xyz")],
+            body=b"",
+        )
+        mock_client.request.return_value = mock_response
+        mock_client_class.return_value = mock_client
+
+        session = Session()
+        session.request("GET", "https://example.com/path")
+
+        # Check cookie was stored
+        assert session.cookies.cookie_header("example.com") == "token=xyz"
+
+    @patch('gakido.session.Client')
+    def test_get_method(self, mock_client_class):
+        """Test get() method calls request with GET."""
+        mock_client = MagicMock()
+        mock_response = Response(200, "OK", "1.1", headers=[], body=b"")
+        mock_client.request.return_value = mock_response
+        mock_client_class.return_value = mock_client
+
+        session = Session()
+        session.get("https://example.com")
+
+        mock_client.request.assert_called()
+        args, kwargs = mock_client.request.call_args
+        assert args[0] == "GET"
+
+    @patch('gakido.session.Client')
+    def test_post_method(self, mock_client_class):
+        """Test post() method calls request with POST."""
+        mock_client = MagicMock()
+        mock_response = Response(200, "OK", "1.1", headers=[], body=b"")
+        mock_client.request.return_value = mock_response
+        mock_client_class.return_value = mock_client
+
+        session = Session()
+        session.post("https://example.com", data={"key": "value"})
+
+        mock_client.request.assert_called()
+        args, kwargs = mock_client.request.call_args
+        assert args[0] == "POST"
+
+    @patch('gakido.session.Client')
+    def test_close_closes_client(self, mock_client_class):
+        """Test close() closes the client."""
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+
+        session = Session()
+        session.close()
+
+        mock_client.close.assert_called_once()
+
+    @patch('gakido.session.Client')
+    def test_context_manager_enter(self, mock_client_class):
+        """Test Session can be used as context manager."""
+        session = Session()
+        result = session.__enter__()
+        assert result is session
+
+    @patch('gakido.session.Client')
+    def test_context_manager_exit(self, mock_client_class):
+        """Test Session context manager calls close on exit."""
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+
+        with Session() as session:
+            pass
+
+        mock_client.close.assert_called_once()
+
+    @patch('gakido.session.Client')
+    def test_request_no_cookie_when_not_set(self, mock_client_class):
+        """Test request doesn't add Cookie header when no cookies."""
+        mock_client = MagicMock()
+        mock_response = Response(200, "OK", "1.1", headers=[], body=b"")
+        mock_client.request.return_value = mock_response
+        mock_client_class.return_value = mock_client
+
+        session = Session()
+        session.request("GET", "https://example.com/path", headers={"X-Custom": "value"})
+
+        call_args = mock_client.request.call_args
+        headers = call_args.kwargs.get("headers") or call_args[1].get("headers", {})
+        # Should have X-Custom but no Cookie (since jar is empty for this host)
+        assert "X-Custom" in headers
+
+    @patch('gakido.session.Client')
+    def test_user_cookie_header_not_overwritten(self, mock_client_class):
+        """Test user-provided Cookie header is not overwritten."""
+        mock_client = MagicMock()
+        mock_response = Response(200, "OK", "1.1", headers=[], body=b"")
+        mock_client.request.return_value = mock_response
+        mock_client_class.return_value = mock_client
+
+        session = Session()
+        # Pre-set a cookie in jar
+        session.cookies.store["example.com"] = {"session": "from_jar"}
+
+        # But provide our own Cookie header
+        session.request("GET", "https://example.com/path", headers={"Cookie": "user_cookie=value"})
+
+        call_args = mock_client.request.call_args
+        headers = call_args.kwargs.get("headers") or call_args[1].get("headers", {})
+        # User cookie should be preserved
+        assert headers.get("Cookie") == "user_cookie=value"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,85 @@
+"""Tests for gakido.utils module."""
+
+import pytest
+from gakido.utils import parse_url
+
+
+class TestParseUrl:
+    """Tests for parse_url function."""
+
+    def test_parse_https_url(self):
+        """Test parsing HTTPS URL."""
+        parsed, host, port, path = parse_url("https://example.com/path")
+        assert host == "example.com"
+        assert port == 443
+        assert path == "/path"
+        assert parsed.scheme == "https"
+
+    def test_parse_http_url(self):
+        """Test parsing HTTP URL."""
+        parsed, host, port, path = parse_url("http://example.com/path")
+        assert host == "example.com"
+        assert port == 80
+        assert path == "/path"
+        assert parsed.scheme == "http"
+
+    def test_parse_url_custom_port(self):
+        """Test parsing URL with custom port."""
+        parsed, host, port, path = parse_url("https://example.com:8443/api")
+        assert host == "example.com"
+        assert port == 8443
+        assert path == "/api"
+
+    def test_parse_url_with_query_string(self):
+        """Test parsing URL with query string."""
+        parsed, host, port, path = parse_url("https://example.com/search?q=test&page=1")
+        assert host == "example.com"
+        assert port == 443
+        assert path == "/search?q=test&page=1"
+
+    def test_parse_url_empty_path(self):
+        """Test parsing URL with empty path defaults to /."""
+        parsed, host, port, path = parse_url("https://example.com")
+        assert path == "/"
+
+    def test_parse_url_root_path(self):
+        """Test parsing URL with root path."""
+        parsed, host, port, path = parse_url("https://example.com/")
+        assert path == "/"
+
+    def test_parse_url_invalid_scheme_raises(self):
+        """Test invalid scheme raises ValueError."""
+        with pytest.raises(ValueError, match="Only http and https"):
+            parse_url("ftp://example.com")
+
+    def test_parse_url_no_scheme_raises(self):
+        """Test URL without scheme raises."""
+        with pytest.raises(ValueError):
+            parse_url("example.com/path")
+
+    def test_parse_url_file_scheme_raises(self):
+        """Test file:// scheme raises ValueError."""
+        with pytest.raises(ValueError, match="Only http and https"):
+            parse_url("file:///etc/passwd")
+
+    def test_parse_url_with_fragment(self):
+        """Test parsing URL with fragment (fragment not included in path)."""
+        parsed, host, port, path = parse_url("https://example.com/page#section")
+        assert host == "example.com"
+        # Fragment is not part of path sent to server
+        assert path == "/page"
+
+    def test_parse_url_complex_path(self):
+        """Test parsing URL with complex path."""
+        url = "https://api.example.com:9000/v1/users/123/posts?limit=10&offset=20"
+        parsed, host, port, path = parse_url(url)
+        assert host == "api.example.com"
+        assert port == 9000
+        assert path == "/v1/users/123/posts?limit=10&offset=20"
+
+    def test_parse_url_ipv4_host(self):
+        """Test parsing URL with IPv4 host."""
+        parsed, host, port, path = parse_url("http://192.168.1.1:8080/api")
+        assert host == "192.168.1.1"
+        assert port == 8080
+        assert path == "/api"

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -1,0 +1,380 @@
+"""Tests for gakido.websocket module."""
+
+import pytest
+from unittest.mock import Mock, MagicMock, patch
+import socket
+import ssl
+import struct
+import base64
+import hashlib
+import os
+
+from gakido.websocket import WebSocket
+
+
+class TestWebSocketConnect:
+    """Tests for WebSocket.connect class method."""
+
+    @patch('gakido.websocket.ssl.create_default_context')
+    @patch('gakido.websocket.socket.create_connection')
+    @patch('gakido.websocket.os.urandom')
+    def test_connect_ws(self, mock_urandom, mock_create_conn, mock_ssl_ctx):
+        """Test WebSocket connection without TLS."""
+        mock_urandom.return_value = b"1234567890123456"  # 16 bytes for key
+        mock_sock = MagicMock()
+        mock_create_conn.return_value = mock_sock
+
+        # Simulate successful upgrade response
+        key = base64.b64encode(b"1234567890123456").decode()
+        accept = base64.b64encode(
+            hashlib.sha1((key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11").encode()).digest()
+        ).decode()
+
+        response = f"HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: {accept}\r\n\r\n"
+        mock_sock.recv.return_value = response.encode()
+
+        ws = WebSocket.connect(
+            host="example.com",
+            port=80,
+            resource="/ws",
+            headers=[("Origin", "http://example.com")],
+            tls=False,
+        )
+
+        assert isinstance(ws, WebSocket)
+        mock_create_conn.assert_called_once_with(("example.com", 80), timeout=10.0)
+
+    @patch('gakido.websocket.ssl.create_default_context')
+    @patch('gakido.websocket.socket.create_connection')
+    @patch('gakido.websocket.os.urandom')
+    def test_connect_wss(self, mock_urandom, mock_create_conn, mock_ssl_ctx):
+        """Test WebSocket connection with TLS."""
+        mock_urandom.return_value = b"1234567890123456"
+        mock_sock = MagicMock()
+        mock_wrapped = MagicMock()
+        mock_create_conn.return_value = mock_sock
+        mock_ctx = MagicMock()
+        mock_ctx.wrap_socket.return_value = mock_wrapped
+        mock_ssl_ctx.return_value = mock_ctx
+
+        key = base64.b64encode(b"1234567890123456").decode()
+        accept = base64.b64encode(
+            hashlib.sha1((key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11").encode()).digest()
+        ).decode()
+
+        response = f"HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: {accept}\r\n\r\n"
+        mock_wrapped.recv.return_value = response.encode()
+
+        ws = WebSocket.connect(
+            host="example.com",
+            port=443,
+            resource="/ws",
+            headers=[],
+            tls=True,
+        )
+
+        assert isinstance(ws, WebSocket)
+        mock_ctx.wrap_socket.assert_called_once_with(mock_sock, server_hostname="example.com")
+
+    @patch('gakido.websocket.socket.create_connection')
+    @patch('gakido.websocket.os.urandom')
+    def test_connect_upgrade_failed_raises(self, mock_urandom, mock_create_conn):
+        """Test connect raises on failed upgrade."""
+        mock_urandom.return_value = b"1234567890123456"
+        mock_sock = MagicMock()
+        mock_create_conn.return_value = mock_sock
+
+        # Non-101 response
+        mock_sock.recv.return_value = b"HTTP/1.1 400 Bad Request\r\n\r\n"
+
+        with pytest.raises(RuntimeError, match="WebSocket upgrade failed"):
+            WebSocket.connect(
+                host="example.com",
+                port=80,
+                resource="/ws",
+                headers=[],
+            )
+
+        mock_sock.close.assert_called()
+
+    @patch('gakido.websocket.socket.create_connection')
+    @patch('gakido.websocket.os.urandom')
+    def test_connect_accept_mismatch_raises(self, mock_urandom, mock_create_conn):
+        """Test connect raises on accept key mismatch."""
+        mock_urandom.return_value = b"1234567890123456"
+        mock_sock = MagicMock()
+        mock_create_conn.return_value = mock_sock
+
+        # Response with wrong accept key
+        response = "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: wrongkey\r\n\r\n"
+        mock_sock.recv.return_value = response.encode()
+
+        with pytest.raises(RuntimeError, match="WebSocket accept mismatch"):
+            WebSocket.connect(
+                host="example.com",
+                port=80,
+                resource="/ws",
+                headers=[],
+            )
+
+    @patch('gakido.websocket.socket.create_connection')
+    @patch('gakido.websocket.os.urandom')
+    def test_connect_with_custom_headers(self, mock_urandom, mock_create_conn):
+        """Test connect sends custom headers."""
+        mock_urandom.return_value = b"1234567890123456"
+        mock_sock = MagicMock()
+        mock_create_conn.return_value = mock_sock
+
+        key = base64.b64encode(b"1234567890123456").decode()
+        accept = base64.b64encode(
+            hashlib.sha1((key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11").encode()).digest()
+        ).decode()
+
+        response = f"HTTP/1.1 101 Switching Protocols\r\nSec-WebSocket-Accept: {accept}\r\n\r\n"
+        mock_sock.recv.return_value = response.encode()
+
+        WebSocket.connect(
+            host="example.com",
+            port=80,
+            resource="/ws",
+            headers=[
+                ("Authorization", "Bearer token"),
+                ("X-Custom", "value"),
+            ],
+        )
+
+        # Check sendall was called with custom headers
+        sent_data = mock_sock.sendall.call_args[0][0].decode()
+        assert "Authorization: Bearer token" in sent_data
+        assert "X-Custom: value" in sent_data
+
+
+class TestWebSocketSend:
+    """Tests for WebSocket send methods."""
+
+    def test_send_text(self):
+        """Test sending text message."""
+        mock_sock = MagicMock()
+        ws = WebSocket(mock_sock)
+
+        with patch('gakido.websocket.os.urandom', return_value=b"\x00\x00\x00\x00"):
+            ws.send_text("hello")
+
+        mock_sock.sendall.assert_called_once()
+        sent = mock_sock.sendall.call_args[0][0]
+
+        # Check opcode is 0x81 (FIN + text)
+        assert sent[0] == 0x81
+
+    def test_send_bytes(self):
+        """Test sending binary message."""
+        mock_sock = MagicMock()
+        ws = WebSocket(mock_sock)
+
+        with patch('gakido.websocket.os.urandom', return_value=b"\x00\x00\x00\x00"):
+            ws.send_bytes(b"binary data")
+
+        mock_sock.sendall.assert_called_once()
+        sent = mock_sock.sendall.call_args[0][0]
+
+        # Check opcode is 0x82 (FIN + binary)
+        assert sent[0] == 0x82
+
+
+class TestWebSocketSendFrame:
+    """Tests for WebSocket._send_frame method."""
+
+    def test_send_frame_small_payload(self):
+        """Test sending small payload (< 126 bytes)."""
+        mock_sock = MagicMock()
+        ws = WebSocket(mock_sock)
+
+        with patch('gakido.websocket.os.urandom', return_value=b"\x00\x00\x00\x00"):
+            ws._send_frame(0x1, b"hello")
+
+        sent = mock_sock.sendall.call_args[0][0]
+        # FIN + opcode
+        assert sent[0] == 0x81
+        # MASK bit + length
+        assert sent[1] == 0x85  # 0x80 | 5
+
+    def test_send_frame_medium_payload(self):
+        """Test sending medium payload (126-65535 bytes)."""
+        mock_sock = MagicMock()
+        ws = WebSocket(mock_sock)
+
+        payload = b"x" * 200
+
+        with patch('gakido.websocket.os.urandom', return_value=b"\x00\x00\x00\x00"):
+            ws._send_frame(0x1, payload)
+
+        sent = mock_sock.sendall.call_args[0][0]
+        # MASK bit + 126 indicator
+        assert sent[1] == 0xFE  # 0x80 | 126
+        # Extended payload length
+        length = struct.unpack("!H", sent[2:4])[0]
+        assert length == 200
+
+    def test_send_frame_large_payload(self):
+        """Test sending large payload (> 65535 bytes)."""
+        mock_sock = MagicMock()
+        ws = WebSocket(mock_sock)
+
+        payload = b"x" * 70000
+
+        with patch('gakido.websocket.os.urandom', return_value=b"\x00\x00\x00\x00"):
+            ws._send_frame(0x1, payload)
+
+        sent = mock_sock.sendall.call_args[0][0]
+        # MASK bit + 127 indicator
+        assert sent[1] == 0xFF  # 0x80 | 127
+        # Extended payload length (8 bytes)
+        length = struct.unpack("!Q", sent[2:10])[0]
+        assert length == 70000
+
+
+class TestWebSocketRecv:
+    """Tests for WebSocket recv methods."""
+
+    def test_recv(self):
+        """Test receiving a message."""
+        mock_sock = MagicMock()
+        ws = WebSocket(mock_sock)
+
+        # Simulate receiving a text frame: FIN + opcode=1, no mask, length=5, "hello"
+        frame = bytes([0x81, 0x05]) + b"hello"
+        idx = [0]
+
+        def recv_side_effect(n):
+            start = idx[0]
+            end = min(start + n, len(frame))
+            idx[0] = end
+            return frame[start:end]
+
+        mock_sock.recv.side_effect = recv_side_effect
+
+        opcode, payload = ws.recv()
+
+        assert opcode == 0x01
+        assert payload == b"hello"
+
+    def test_recv_masked_frame(self):
+        """Test receiving a masked frame (server shouldn't send masked frames, but test anyway)."""
+        mock_sock = MagicMock()
+        ws = WebSocket(mock_sock)
+
+        # Masked frame with mask key and payload
+        mask_key = b"\x12\x34\x56\x78"
+        payload = b"hello"
+        masked_payload = bytes(b ^ mask_key[i % 4] for i, b in enumerate(payload))
+
+        frame = bytes([0x81, 0x85]) + mask_key + masked_payload  # 0x85 = 0x80 | 5 (masked + length)
+        idx = [0]
+
+        def recv_side_effect(n):
+            start = idx[0]
+            end = min(start + n, len(frame))
+            idx[0] = end
+            return frame[start:end]
+
+        mock_sock.recv.side_effect = recv_side_effect
+
+        opcode, result = ws.recv()
+
+        assert result == b"hello"
+
+    def test_recv_extended_length_16(self):
+        """Test receiving frame with 16-bit extended length."""
+        mock_sock = MagicMock()
+        ws = WebSocket(mock_sock)
+
+        payload = b"x" * 200
+        # FIN + text, length=126 indicator, then 2-byte length
+        frame = bytes([0x81, 126]) + struct.pack("!H", 200) + payload
+        idx = [0]
+
+        def recv_side_effect(n):
+            start = idx[0]
+            end = min(start + n, len(frame))
+            idx[0] = end
+            return frame[start:end]
+
+        mock_sock.recv.side_effect = recv_side_effect
+
+        opcode, result = ws.recv()
+
+        assert len(result) == 200
+
+    def test_recv_extended_length_64(self):
+        """Test receiving frame with 64-bit extended length."""
+        mock_sock = MagicMock()
+        ws = WebSocket(mock_sock)
+
+        payload = b"x" * 70000
+        # FIN + text, length=127 indicator, then 8-byte length
+        frame = bytes([0x81, 127]) + struct.pack("!Q", 70000) + payload
+        idx = [0]
+
+        def recv_side_effect(n):
+            start = idx[0]
+            end = min(start + n, len(frame))
+            idx[0] = end
+            return frame[start:end]
+
+        mock_sock.recv.side_effect = recv_side_effect
+
+        opcode, result = ws.recv()
+
+        assert len(result) == 70000
+
+
+class TestWebSocketClose:
+    """Tests for WebSocket.close method."""
+
+    def test_close_sends_close_frame(self):
+        """Test close sends close frame."""
+        mock_sock = MagicMock()
+        ws = WebSocket(mock_sock)
+
+        with patch('gakido.websocket.os.urandom', return_value=b"\x00\x00\x00\x00"):
+            ws.close()
+
+        # Should send close frame (opcode 0x8) then close socket
+        sent = mock_sock.sendall.call_args[0][0]
+        assert sent[0] == 0x88  # FIN + close opcode
+        mock_sock.close.assert_called_once()
+
+
+class TestWebSocketRecvExact:
+    """Tests for WebSocket._recv_exact method."""
+
+    def test_recv_exact(self):
+        """Test _recv_exact reads exact number of bytes."""
+        mock_sock = MagicMock()
+        ws = WebSocket(mock_sock)
+
+        mock_sock.recv.side_effect = [b"hell", b"lo"]
+
+        result = ws._recv_exact(5)
+
+        assert result == b"helllo"
+
+    def test_recv_exact_socket_closed_raises(self):
+        """Test _recv_exact raises on socket close."""
+        mock_sock = MagicMock()
+        mock_sock.recv.return_value = b""
+        ws = WebSocket(mock_sock)
+
+        with pytest.raises(RuntimeError, match="Socket closed"):
+            ws._recv_exact(10)
+
+
+class TestWebSocketInit:
+    """Tests for WebSocket initialization."""
+
+    def test_init_stores_socket(self):
+        """Test WebSocket stores socket reference."""
+        mock_sock = MagicMock()
+        ws = WebSocket(mock_sock)
+
+        assert ws.sock is mock_sock

--- a/uv.lock
+++ b/uv.lock
@@ -295,6 +295,98 @@ wheels = [
 ]
 
 [[package]]
+name = "coverage"
+version = "7.13.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/23/f9/e92df5e07f3fc8d4c7f9a0f146ef75446bf870351cd37b788cf5897f8079/coverage-7.13.1.tar.gz", hash = "sha256:b7593fe7eb5feaa3fbb461ac79aac9f9fc0387a5ca8080b0c6fe2ca27b091afd", size = 825862, upload-time = "2025-12-28T15:42:56.969Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/9b/77baf488516e9ced25fc215a6f75d803493fc3f6a1a1227ac35697910c2a/coverage-7.13.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1a55d509a1dc5a5b708b5dad3b5334e07a16ad4c2185e27b40e4dba796ab7f88", size = 218755, upload-time = "2025-12-28T15:40:30.812Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/cd/7ab01154e6eb79ee2fab76bf4d89e94c6648116557307ee4ebbb85e5c1bf/coverage-7.13.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4d010d080c4888371033baab27e47c9df7d6fb28d0b7b7adf85a4a49be9298b3", size = 219257, upload-time = "2025-12-28T15:40:32.333Z" },
+    { url = "https://files.pythonhosted.org/packages/01/d5/b11ef7863ffbbdb509da0023fad1e9eda1c0eaea61a6d2ea5b17d4ac706e/coverage-7.13.1-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:d938b4a840fb1523b9dfbbb454f652967f18e197569c32266d4d13f37244c3d9", size = 249657, upload-time = "2025-12-28T15:40:34.1Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/7c/347280982982383621d29b8c544cf497ae07ac41e44b1ca4903024131f55/coverage-7.13.1-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:bf100a3288f9bb7f919b87eb84f87101e197535b9bd0e2c2b5b3179633324fee", size = 251581, upload-time = "2025-12-28T15:40:36.131Z" },
+    { url = "https://files.pythonhosted.org/packages/82/f6/ebcfed11036ade4c0d75fa4453a6282bdd225bc073862766eec184a4c643/coverage-7.13.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef6688db9bf91ba111ae734ba6ef1a063304a881749726e0d3575f5c10a9facf", size = 253691, upload-time = "2025-12-28T15:40:37.626Z" },
+    { url = "https://files.pythonhosted.org/packages/02/92/af8f5582787f5d1a8b130b2dcba785fa5e9a7a8e121a0bb2220a6fdbdb8a/coverage-7.13.1-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0b609fc9cdbd1f02e51f67f51e5aee60a841ef58a68d00d5ee2c0faf357481a3", size = 249799, upload-time = "2025-12-28T15:40:39.47Z" },
+    { url = "https://files.pythonhosted.org/packages/24/aa/0e39a2a3b16eebf7f193863323edbff38b6daba711abaaf807d4290cf61a/coverage-7.13.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c43257717611ff5e9a1d79dce8e47566235ebda63328718d9b65dd640bc832ef", size = 251389, upload-time = "2025-12-28T15:40:40.954Z" },
+    { url = "https://files.pythonhosted.org/packages/73/46/7f0c13111154dc5b978900c0ccee2e2ca239b910890e674a77f1363d483e/coverage-7.13.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:e09fbecc007f7b6afdfb3b07ce5bd9f8494b6856dd4f577d26c66c391b829851", size = 249450, upload-time = "2025-12-28T15:40:42.489Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ca/e80da6769e8b669ec3695598c58eef7ad98b0e26e66333996aee6316db23/coverage-7.13.1-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:a03a4f3a19a189919c7055098790285cc5c5b0b3976f8d227aea39dbf9f8bfdb", size = 249170, upload-time = "2025-12-28T15:40:44.279Z" },
+    { url = "https://files.pythonhosted.org/packages/af/18/9e29baabdec1a8644157f572541079b4658199cfd372a578f84228e860de/coverage-7.13.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3820778ea1387c2b6a818caec01c63adc5b3750211af6447e8dcfb9b6f08dbba", size = 250081, upload-time = "2025-12-28T15:40:45.748Z" },
+    { url = "https://files.pythonhosted.org/packages/00/f8/c3021625a71c3b2f516464d322e41636aea381018319050a8114105872ee/coverage-7.13.1-cp311-cp311-win32.whl", hash = "sha256:ff10896fa55167371960c5908150b434b71c876dfab97b69478f22c8b445ea19", size = 221281, upload-time = "2025-12-28T15:40:47.232Z" },
+    { url = "https://files.pythonhosted.org/packages/27/56/c216625f453df6e0559ed666d246fcbaaa93f3aa99eaa5080cea1229aa3d/coverage-7.13.1-cp311-cp311-win_amd64.whl", hash = "sha256:a998cc0aeeea4c6d5622a3754da5a493055d2d95186bad877b0a34ea6e6dbe0a", size = 222215, upload-time = "2025-12-28T15:40:49.19Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/9a/be342e76f6e531cae6406dc46af0d350586f24d9b67fdfa6daee02df71af/coverage-7.13.1-cp311-cp311-win_arm64.whl", hash = "sha256:fea07c1a39a22614acb762e3fbbb4011f65eedafcb2948feeef641ac78b4ee5c", size = 220886, upload-time = "2025-12-28T15:40:51.067Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/8a/87af46cccdfa78f53db747b09f5f9a21d5fc38d796834adac09b30a8ce74/coverage-7.13.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6f34591000f06e62085b1865c9bc5f7858df748834662a51edadfd2c3bfe0dd3", size = 218927, upload-time = "2025-12-28T15:40:52.814Z" },
+    { url = "https://files.pythonhosted.org/packages/82/a8/6e22fdc67242a4a5a153f9438d05944553121c8f4ba70cb072af4c41362e/coverage-7.13.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b67e47c5595b9224599016e333f5ec25392597a89d5744658f837d204e16c63e", size = 219288, upload-time = "2025-12-28T15:40:54.262Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/0a/853a76e03b0f7c4375e2ca025df45c918beb367f3e20a0a8e91967f6e96c/coverage-7.13.1-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:3e7b8bd70c48ffb28461ebe092c2345536fb18bbbf19d287c8913699735f505c", size = 250786, upload-time = "2025-12-28T15:40:56.059Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/b4/694159c15c52b9f7ec7adf49d50e5f8ee71d3e9ef38adb4445d13dd56c20/coverage-7.13.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c223d078112e90dc0e5c4e35b98b9584164bea9fbbd221c0b21c5241f6d51b62", size = 253543, upload-time = "2025-12-28T15:40:57.585Z" },
+    { url = "https://files.pythonhosted.org/packages/96/b2/7f1f0437a5c855f87e17cf5d0dc35920b6440ff2b58b1ba9788c059c26c8/coverage-7.13.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:794f7c05af0763b1bbd1b9e6eff0e52ad068be3b12cd96c87de037b01390c968", size = 254635, upload-time = "2025-12-28T15:40:59.443Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/d1/73c3fdb8d7d3bddd9473c9c6a2e0682f09fc3dfbcb9c3f36412a7368bcab/coverage-7.13.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0642eae483cc8c2902e4af7298bf886d605e80f26382124cddc3967c2a3df09e", size = 251202, upload-time = "2025-12-28T15:41:01.328Z" },
+    { url = "https://files.pythonhosted.org/packages/66/3c/f0edf75dcc152f145d5598329e864bbbe04ab78660fe3e8e395f9fff010f/coverage-7.13.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:9f5e772ed5fef25b3de9f2008fe67b92d46831bd2bc5bdc5dd6bfd06b83b316f", size = 252566, upload-time = "2025-12-28T15:41:03.319Z" },
+    { url = "https://files.pythonhosted.org/packages/17/b3/e64206d3c5f7dcbceafd14941345a754d3dbc78a823a6ed526e23b9cdaab/coverage-7.13.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:45980ea19277dc0a579e432aef6a504fe098ef3a9032ead15e446eb0f1191aee", size = 250711, upload-time = "2025-12-28T15:41:06.411Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/ad/28a3eb970a8ef5b479ee7f0c484a19c34e277479a5b70269dc652b730733/coverage-7.13.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:e4f18eca6028ffa62adbd185a8f1e1dd242f2e68164dba5c2b74a5204850b4cf", size = 250278, upload-time = "2025-12-28T15:41:08.285Z" },
+    { url = "https://files.pythonhosted.org/packages/54/e3/c8f0f1a93133e3e1291ca76cbb63565bd4b5c5df63b141f539d747fff348/coverage-7.13.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f8dca5590fec7a89ed6826fce625595279e586ead52e9e958d3237821fbc750c", size = 252154, upload-time = "2025-12-28T15:41:09.969Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/bf/9939c5d6859c380e405b19e736321f1c7d402728792f4c752ad1adcce005/coverage-7.13.1-cp312-cp312-win32.whl", hash = "sha256:ff86d4e85188bba72cfb876df3e11fa243439882c55957184af44a35bd5880b7", size = 221487, upload-time = "2025-12-28T15:41:11.468Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/dc/7282856a407c621c2aad74021680a01b23010bb8ebf427cf5eacda2e876f/coverage-7.13.1-cp312-cp312-win_amd64.whl", hash = "sha256:16cc1da46c04fb0fb128b4dc430b78fa2aba8a6c0c9f8eb391fd5103409a6ac6", size = 222299, upload-time = "2025-12-28T15:41:13.386Z" },
+    { url = "https://files.pythonhosted.org/packages/10/79/176a11203412c350b3e9578620013af35bcdb79b651eb976f4a4b32044fa/coverage-7.13.1-cp312-cp312-win_arm64.whl", hash = "sha256:8d9bc218650022a768f3775dd7fdac1886437325d8d295d923ebcfef4892ad5c", size = 220941, upload-time = "2025-12-28T15:41:14.975Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/a4/e98e689347a1ff1a7f67932ab535cef82eb5e78f32a9e4132e114bbb3a0a/coverage-7.13.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:cb237bfd0ef4d5eb6a19e29f9e528ac67ac3be932ea6b44fb6cc09b9f3ecff78", size = 218951, upload-time = "2025-12-28T15:41:16.653Z" },
+    { url = "https://files.pythonhosted.org/packages/32/33/7cbfe2bdc6e2f03d6b240d23dc45fdaf3fd270aaf2d640be77b7f16989ab/coverage-7.13.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1dcb645d7e34dcbcc96cd7c132b1fc55c39263ca62eb961c064eb3928997363b", size = 219325, upload-time = "2025-12-28T15:41:18.609Z" },
+    { url = "https://files.pythonhosted.org/packages/59/f6/efdabdb4929487baeb7cb2a9f7dac457d9356f6ad1b255be283d58b16316/coverage-7.13.1-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:3d42df8201e00384736f0df9be2ced39324c3907607d17d50d50116c989d84cd", size = 250309, upload-time = "2025-12-28T15:41:20.629Z" },
+    { url = "https://files.pythonhosted.org/packages/12/da/91a52516e9d5aea87d32d1523f9cdcf7a35a3b298e6be05d6509ba3cfab2/coverage-7.13.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fa3edde1aa8807de1d05934982416cb3ec46d1d4d91e280bcce7cca01c507992", size = 252907, upload-time = "2025-12-28T15:41:22.257Z" },
+    { url = "https://files.pythonhosted.org/packages/75/38/f1ea837e3dc1231e086db1638947e00d264e7e8c41aa8ecacf6e1e0c05f4/coverage-7.13.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9edd0e01a343766add6817bc448408858ba6b489039eaaa2018474e4001651a4", size = 254148, upload-time = "2025-12-28T15:41:23.87Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/43/f4f16b881aaa34954ba446318dea6b9ed5405dd725dd8daac2358eda869a/coverage-7.13.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:985b7836931d033570b94c94713c6dba5f9d3ff26045f72c3e5dbc5fe3361e5a", size = 250515, upload-time = "2025-12-28T15:41:25.437Z" },
+    { url = "https://files.pythonhosted.org/packages/84/34/8cba7f00078bd468ea914134e0144263194ce849ec3baad187ffb6203d1c/coverage-7.13.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ffed1e4980889765c84a5d1a566159e363b71d6b6fbaf0bebc9d3c30bc016766", size = 252292, upload-time = "2025-12-28T15:41:28.459Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/a4/cffac66c7652d84ee4ac52d3ccb94c015687d3b513f9db04bfcac2ac800d/coverage-7.13.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:8842af7f175078456b8b17f1b73a0d16a65dcbdc653ecefeb00a56b3c8c298c4", size = 250242, upload-time = "2025-12-28T15:41:30.02Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/78/9a64d462263dde416f3c0067efade7b52b52796f489b1037a95b0dc389c9/coverage-7.13.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:ccd7a6fca48ca9c131d9b0a2972a581e28b13416fc313fb98b6d24a03ce9a398", size = 250068, upload-time = "2025-12-28T15:41:32.007Z" },
+    { url = "https://files.pythonhosted.org/packages/69/c8/a8994f5fece06db7c4a97c8fc1973684e178599b42e66280dded0524ef00/coverage-7.13.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0403f647055de2609be776965108447deb8e384fe4a553c119e3ff6bfbab4784", size = 251846, upload-time = "2025-12-28T15:41:33.946Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/f7/91fa73c4b80305c86598a2d4e54ba22df6bf7d0d97500944af7ef155d9f7/coverage-7.13.1-cp313-cp313-win32.whl", hash = "sha256:549d195116a1ba1e1ae2f5ca143f9777800f6636eab917d4f02b5310d6d73461", size = 221512, upload-time = "2025-12-28T15:41:35.519Z" },
+    { url = "https://files.pythonhosted.org/packages/45/0b/0768b4231d5a044da8f75e097a8714ae1041246bb765d6b5563bab456735/coverage-7.13.1-cp313-cp313-win_amd64.whl", hash = "sha256:5899d28b5276f536fcf840b18b61a9fce23cc3aec1d114c44c07fe94ebeaa500", size = 222321, upload-time = "2025-12-28T15:41:37.371Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/b8/bdcb7253b7e85157282450262008f1366aa04663f3e3e4c30436f596c3e2/coverage-7.13.1-cp313-cp313-win_arm64.whl", hash = "sha256:868a2fae76dfb06e87291bcbd4dcbcc778a8500510b618d50496e520bd94d9b9", size = 220949, upload-time = "2025-12-28T15:41:39.553Z" },
+    { url = "https://files.pythonhosted.org/packages/70/52/f2be52cc445ff75ea8397948c96c1b4ee14f7f9086ea62fc929c5ae7b717/coverage-7.13.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:67170979de0dacac3f3097d02b0ad188d8edcea44ccc44aaa0550af49150c7dc", size = 219643, upload-time = "2025-12-28T15:41:41.567Z" },
+    { url = "https://files.pythonhosted.org/packages/47/79/c85e378eaa239e2edec0c5523f71542c7793fe3340954eafb0bc3904d32d/coverage-7.13.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:f80e2bb21bfab56ed7405c2d79d34b5dc0bc96c2c1d2a067b643a09fb756c43a", size = 219997, upload-time = "2025-12-28T15:41:43.418Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/9b/b1ade8bfb653c0bbce2d6d6e90cc6c254cbb99b7248531cc76253cb4da6d/coverage-7.13.1-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:f83351e0f7dcdb14d7326c3d8d8c4e915fa685cbfdc6281f9470d97a04e9dfe4", size = 261296, upload-time = "2025-12-28T15:41:45.207Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/af/ebf91e3e1a2473d523e87e87fd8581e0aa08741b96265730e2d79ce78d8d/coverage-7.13.1-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:bb3f6562e89bad0110afbe64e485aac2462efdce6232cdec7862a095dc3412f6", size = 263363, upload-time = "2025-12-28T15:41:47.163Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/8b/fb2423526d446596624ac7fde12ea4262e66f86f5120114c3cfd0bb2befa/coverage-7.13.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:77545b5dcda13b70f872c3b5974ac64c21d05e65b1590b441c8560115dc3a0d1", size = 265783, upload-time = "2025-12-28T15:41:49.03Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/26/ef2adb1e22674913b89f0fe7490ecadcef4a71fa96f5ced90c60ec358789/coverage-7.13.1-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a4d240d260a1aed814790bbe1f10a5ff31ce6c21bc78f0da4a1e8268d6c80dbd", size = 260508, upload-time = "2025-12-28T15:41:51.035Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/7d/f0f59b3404caf662e7b5346247883887687c074ce67ba453ea08c612b1d5/coverage-7.13.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:d2287ac9360dec3837bfdad969963a5d073a09a85d898bd86bea82aa8876ef3c", size = 263357, upload-time = "2025-12-28T15:41:52.631Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/b1/29896492b0b1a047604d35d6fa804f12818fa30cdad660763a5f3159e158/coverage-7.13.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:0d2c11f3ea4db66b5cbded23b20185c35066892c67d80ec4be4bab257b9ad1e0", size = 260978, upload-time = "2025-12-28T15:41:54.589Z" },
+    { url = "https://files.pythonhosted.org/packages/48/f2/971de1238a62e6f0a4128d37adadc8bb882ee96afbe03ff1570291754629/coverage-7.13.1-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:3fc6a169517ca0d7ca6846c3c5392ef2b9e38896f61d615cb75b9e7134d4ee1e", size = 259877, upload-time = "2025-12-28T15:41:56.263Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/fc/0474efcbb590ff8628830e9aaec5f1831594874360e3251f1fdec31d07a3/coverage-7.13.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:d10a2ed46386e850bb3de503a54f9fe8192e5917fcbb143bfef653a9355e9a53", size = 262069, upload-time = "2025-12-28T15:41:58.093Z" },
+    { url = "https://files.pythonhosted.org/packages/88/4f/3c159b7953db37a7b44c0eab8a95c37d1aa4257c47b4602c04022d5cb975/coverage-7.13.1-cp313-cp313t-win32.whl", hash = "sha256:75a6f4aa904301dab8022397a22c0039edc1f51e90b83dbd4464b8a38dc87842", size = 222184, upload-time = "2025-12-28T15:41:59.763Z" },
+    { url = "https://files.pythonhosted.org/packages/58/a5/6b57d28f81417f9335774f20679d9d13b9a8fb90cd6160957aa3b54a2379/coverage-7.13.1-cp313-cp313t-win_amd64.whl", hash = "sha256:309ef5706e95e62578cda256b97f5e097916a2c26247c287bbe74794e7150df2", size = 223250, upload-time = "2025-12-28T15:42:01.52Z" },
+    { url = "https://files.pythonhosted.org/packages/81/7c/160796f3b035acfbb58be80e02e484548595aa67e16a6345e7910ace0a38/coverage-7.13.1-cp313-cp313t-win_arm64.whl", hash = "sha256:92f980729e79b5d16d221038dbf2e8f9a9136afa072f9d5d6ed4cb984b126a09", size = 221521, upload-time = "2025-12-28T15:42:03.275Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/8e/ba0e597560c6563fc0adb902fda6526df5d4aa73bb10adf0574d03bd2206/coverage-7.13.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:97ab3647280d458a1f9adb85244e81587505a43c0c7cff851f5116cd2814b894", size = 218996, upload-time = "2025-12-28T15:42:04.978Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/8e/764c6e116f4221dc7aa26c4061181ff92edb9c799adae6433d18eeba7a14/coverage-7.13.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:8f572d989142e0908e6acf57ad1b9b86989ff057c006d13b76c146ec6a20216a", size = 219326, upload-time = "2025-12-28T15:42:06.691Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/a6/6130dc6d8da28cdcbb0f2bf8865aeca9b157622f7c0031e48c6cf9a0e591/coverage-7.13.1-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:d72140ccf8a147e94274024ff6fd8fb7811354cf7ef88b1f0a988ebaa5bc774f", size = 250374, upload-time = "2025-12-28T15:42:08.786Z" },
+    { url = "https://files.pythonhosted.org/packages/82/2b/783ded568f7cd6b677762f780ad338bf4b4750205860c17c25f7c708995e/coverage-7.13.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:d3c9f051b028810f5a87c88e5d6e9af3c0ff32ef62763bf15d29f740453ca909", size = 252882, upload-time = "2025-12-28T15:42:10.515Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/b2/9808766d082e6a4d59eb0cc881a57fc1600eb2c5882813eefff8254f71b5/coverage-7.13.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f398ba4df52d30b1763f62eed9de5620dcde96e6f491f4c62686736b155aa6e4", size = 254218, upload-time = "2025-12-28T15:42:12.208Z" },
+    { url = "https://files.pythonhosted.org/packages/44/ea/52a985bb447c871cb4d2e376e401116520991b597c85afdde1ea9ef54f2c/coverage-7.13.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:132718176cc723026d201e347f800cd1a9e4b62ccd3f82476950834dad501c75", size = 250391, upload-time = "2025-12-28T15:42:14.21Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/1d/125b36cc12310718873cfc8209ecfbc1008f14f4f5fa0662aa608e579353/coverage-7.13.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9e549d642426e3579b3f4b92d0431543b012dcb6e825c91619d4e93b7363c3f9", size = 252239, upload-time = "2025-12-28T15:42:16.292Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/16/10c1c164950cade470107f9f14bbac8485f8fb8515f515fca53d337e4a7f/coverage-7.13.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:90480b2134999301eea795b3a9dbf606c6fbab1b489150c501da84a959442465", size = 250196, upload-time = "2025-12-28T15:42:18.54Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/c6/cd860fac08780c6fd659732f6ced1b40b79c35977c1356344e44d72ba6c4/coverage-7.13.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e825dbb7f84dfa24663dd75835e7257f8882629fc11f03ecf77d84a75134b864", size = 250008, upload-time = "2025-12-28T15:42:20.365Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/a8c58d3d38f82a5711e1e0a67268362af48e1a03df27c03072ac30feefcf/coverage-7.13.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:623dcc6d7a7ba450bbdbeedbaa0c42b329bdae16491af2282f12a7e809be7eb9", size = 251671, upload-time = "2025-12-28T15:42:22.114Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/bc/fd4c1da651d037a1e3d53e8cb3f8182f4b53271ffa9a95a2e211bacc0349/coverage-7.13.1-cp314-cp314-win32.whl", hash = "sha256:6e73ebb44dca5f708dc871fe0b90cf4cff1a13f9956f747cc87b535a840386f5", size = 221777, upload-time = "2025-12-28T15:42:23.919Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/50/71acabdc8948464c17e90b5ffd92358579bd0910732c2a1c9537d7536aa6/coverage-7.13.1-cp314-cp314-win_amd64.whl", hash = "sha256:be753b225d159feb397bd0bf91ae86f689bad0da09d3b301478cd39b878ab31a", size = 222592, upload-time = "2025-12-28T15:42:25.619Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/c8/a6fb943081bb0cc926499c7907731a6dc9efc2cbdc76d738c0ab752f1a32/coverage-7.13.1-cp314-cp314-win_arm64.whl", hash = "sha256:228b90f613b25ba0019361e4ab81520b343b622fc657daf7e501c4ed6a2366c0", size = 221169, upload-time = "2025-12-28T15:42:27.629Z" },
+    { url = "https://files.pythonhosted.org/packages/16/61/d5b7a0a0e0e40d62e59bc8c7aa1afbd86280d82728ba97f0673b746b78e2/coverage-7.13.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:60cfb538fe9ef86e5b2ab0ca8fc8d62524777f6c611dcaf76dc16fbe9b8e698a", size = 219730, upload-time = "2025-12-28T15:42:29.306Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/2c/8881326445fd071bb49514d1ce97d18a46a980712b51fee84f9ab42845b4/coverage-7.13.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:57dfc8048c72ba48a8c45e188d811e5efd7e49b387effc8fb17e97936dde5bf6", size = 220001, upload-time = "2025-12-28T15:42:31.319Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/d7/50de63af51dfa3a7f91cc37ad8fcc1e244b734232fbc8b9ab0f3c834a5cd/coverage-7.13.1-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:3f2f725aa3e909b3c5fdb8192490bdd8e1495e85906af74fe6e34a2a77ba0673", size = 261370, upload-time = "2025-12-28T15:42:32.992Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/2c/d31722f0ec918fd7453b2758312729f645978d212b410cd0f7c2aed88a94/coverage-7.13.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9ee68b21909686eeb21dfcba2c3b81fee70dcf38b140dcd5aa70680995fa3aa5", size = 263485, upload-time = "2025-12-28T15:42:34.759Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/7a/2c114fa5c5fc08ba0777e4aec4c97e0b4a1afcb69c75f1f54cff78b073ab/coverage-7.13.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:724b1b270cb13ea2e6503476e34541a0b1f62280bc997eab443f87790202033d", size = 265890, upload-time = "2025-12-28T15:42:36.517Z" },
+    { url = "https://files.pythonhosted.org/packages/65/d9/f0794aa1c74ceabc780fe17f6c338456bbc4e96bd950f2e969f48ac6fb20/coverage-7.13.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:916abf1ac5cf7eb16bc540a5bf75c71c43a676f5c52fcb9fe75a2bd75fb944e8", size = 260445, upload-time = "2025-12-28T15:42:38.646Z" },
+    { url = "https://files.pythonhosted.org/packages/49/23/184b22a00d9bb97488863ced9454068c79e413cb23f472da6cbddc6cfc52/coverage-7.13.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:776483fd35b58d8afe3acbd9988d5de592ab6da2d2a865edfdbc9fdb43e7c486", size = 263357, upload-time = "2025-12-28T15:42:40.788Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/bd/58af54c0c9199ea4190284f389005779d7daf7bf3ce40dcd2d2b2f96da69/coverage-7.13.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:b6f3b96617e9852703f5b633ea01315ca45c77e879584f283c44127f0f1ec564", size = 260959, upload-time = "2025-12-28T15:42:42.808Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/2a/6839294e8f78a4891bf1df79d69c536880ba2f970d0ff09e7513d6e352e9/coverage-7.13.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:bd63e7b74661fed317212fab774e2a648bc4bb09b35f25474f8e3325d2945cd7", size = 259792, upload-time = "2025-12-28T15:42:44.818Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/c3/528674d4623283310ad676c5af7414b9850ab6d55c2300e8aa4b945ec554/coverage-7.13.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:933082f161bbb3e9f90d00990dc956120f608cdbcaeea15c4d897f56ef4fe416", size = 262123, upload-time = "2025-12-28T15:42:47.108Z" },
+    { url = "https://files.pythonhosted.org/packages/06/c5/8c0515692fb4c73ac379d8dc09b18eaf0214ecb76ea6e62467ba7a1556ff/coverage-7.13.1-cp314-cp314t-win32.whl", hash = "sha256:18be793c4c87de2965e1c0f060f03d9e5aff66cfeae8e1dbe6e5b88056ec153f", size = 222562, upload-time = "2025-12-28T15:42:49.144Z" },
+    { url = "https://files.pythonhosted.org/packages/05/0e/c0a0c4678cb30dac735811db529b321d7e1c9120b79bd728d4f4d6b010e9/coverage-7.13.1-cp314-cp314t-win_amd64.whl", hash = "sha256:0e42e0ec0cd3e0d851cb3c91f770c9301f48647cb2877cb78f74bdaa07639a79", size = 223670, upload-time = "2025-12-28T15:42:51.218Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/5f/b177aa0011f354abf03a8f30a85032686d290fdeed4222b27d36b4372a50/coverage-7.13.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eaecf47ef10c72ece9a2a92118257da87e460e113b83cc0d2905cbbe931792b4", size = 221707, upload-time = "2025-12-28T15:42:53.034Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/48/d9f421cb8da5afaa1a64570d9989e00fb7955e6acddc5a12979f7666ef60/coverage-7.13.1-py3-none-any.whl", hash = "sha256:2016745cb3ba554469d02819d78958b571792bb68e31302610e898f80dd3a573", size = 210722, upload-time = "2025-12-28T15:42:54.901Z" },
+]
+
+[package.optional-dependencies]
+toml = [
+    { name = "tomli", marker = "python_full_version <= '3.11'" },
+]
+
+[[package]]
 name = "cryptography"
 version = "46.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -377,6 +469,15 @@ dev = [
     { name = "mkdocs-git-revision-date-localized-plugin" },
     { name = "mkdocs-material" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-codspeed" },
+    { name = "pytest-cov" },
+    { name = "pytest-instafail" },
+    { name = "pytest-picked" },
+    { name = "pytest-pretty" },
+    { name = "pytest-sugar" },
+    { name = "pytest-timeout" },
+    { name = "respx" },
     { name = "ruff" },
     { name = "ty" },
 ]
@@ -398,7 +499,16 @@ requires-dist = [
     { name = "mkdocs-material", specifier = ">=9.7.1" },
     { name = "mkdocs-material", marker = "extra == 'dev'", specifier = ">=9.7.1" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.2" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.3.0" },
+    { name = "pytest-codspeed", marker = "extra == 'dev'", specifier = ">=4.2.0" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=7.0.0" },
+    { name = "pytest-instafail", marker = "extra == 'dev'", specifier = ">=0.5.0" },
+    { name = "pytest-picked", marker = "extra == 'dev'", specifier = ">=0.5.1" },
+    { name = "pytest-pretty", marker = "extra == 'dev'", specifier = ">=1.3.0" },
+    { name = "pytest-sugar", marker = "extra == 'dev'", specifier = ">=1.1.1" },
+    { name = "pytest-timeout", marker = "extra == 'dev'", specifier = ">=2.4.0" },
     { name = "requests", specifier = ">=2.32.5" },
+    { name = "respx", marker = "extra == 'dev'", specifier = ">=0.22.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.14.13" },
     { name = "ty", marker = "extra == 'dev'", specifier = ">=0.0.12" },
 ]
@@ -548,6 +658,18 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -619,6 +741,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
     { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
     { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
@@ -860,6 +991,119 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
+name = "pytest-codspeed"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+    { name = "pytest" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e2/e8/27fcbe6516a1c956614a4b61a7fccbf3791ea0b992e07416e8948184327d/pytest_codspeed-4.2.0.tar.gz", hash = "sha256:04b5d0bc5a1851ba1504d46bf9d7dbb355222a69f2cd440d54295db721b331f7", size = 113263, upload-time = "2025-10-24T09:02:55.704Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/2d/f0083a2f14ecf008d961d40439a71da0ae0d568e5f8dc2fccd3e8a2ab3e4/pytest_codspeed-4.2.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2de87bde9fbc6fd53f0fd21dcf2599c89e0b8948d49f9bad224edce51c47e26b", size = 261960, upload-time = "2025-10-24T09:02:40.665Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/0c/1f514c553db4ea5a69dfbe2706734129acd0eca8d5101ec16f1dd00dbc0f/pytest_codspeed-4.2.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:95aeb2479ca383f6b18e2cc9ebcd3b03ab184980a59a232aea6f370bbf59a1e3", size = 250808, upload-time = "2025-10-24T09:02:42.07Z" },
+    { url = "https://files.pythonhosted.org/packages/81/04/479905bd6653bc981c0554fcce6df52d7ae1594e1eefd53e6cf31810ec7f/pytest_codspeed-4.2.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7d4fefbd4ae401e2c60f6be920a0be50eef0c3e4a1f0a1c83962efd45be38b39", size = 262084, upload-time = "2025-10-24T09:02:43.155Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/46/d6f345d7907bac6cbb6224bd697ecbc11cf7427acc9e843c3618f19e3476/pytest_codspeed-4.2.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:309b4227f57fcbb9df21e889ea1ae191d0d1cd8b903b698fdb9ea0461dbf1dfe", size = 251100, upload-time = "2025-10-24T09:02:44.168Z" },
+    { url = "https://files.pythonhosted.org/packages/de/dc/e864f45e994a50390ff49792256f1bdcbf42f170e3bc0470ee1a7d2403f3/pytest_codspeed-4.2.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:72aab8278452a6d020798b9e4f82780966adb00f80d27a25d1274272c54630d5", size = 262057, upload-time = "2025-10-24T09:02:45.791Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/1c/f1d2599784486879cf6579d8d94a3e22108f0e1f130033dab8feefd29249/pytest_codspeed-4.2.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:684fcd9491d810ded653a8d38de4835daa2d001645f4a23942862950664273f8", size = 251013, upload-time = "2025-10-24T09:02:46.937Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/fd/eafd24db5652a94b4d00fe9b309b607de81add0f55f073afb68a378a24b6/pytest_codspeed-4.2.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:50794dabea6ec90d4288904452051e2febace93e7edf4ca9f2bce8019dd8cd37", size = 262065, upload-time = "2025-10-24T09:02:48.018Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/14/8d9340d7dc0ae647991b28a396e16b3403e10def883cde90d6b663d3f7ec/pytest_codspeed-4.2.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a0ebd87f2a99467a1cfd8e83492c4712976e43d353ee0b5f71cbb057f1393aca", size = 251057, upload-time = "2025-10-24T09:02:49.102Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/39/48cf6afbca55bc7c8c93c3d4ae926a1068bcce3f0241709db19b078d5418/pytest_codspeed-4.2.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dbbb2d61b85bef8fc7e2193f723f9ac2db388a48259d981bbce96319043e9830", size = 267983, upload-time = "2025-10-24T09:02:50.558Z" },
+    { url = "https://files.pythonhosted.org/packages/33/86/4407341efb5dceb3e389635749ce1d670542d6ca148bd34f9d5334295faf/pytest_codspeed-4.2.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:748411c832147bfc85f805af78a1ab1684f52d08e14aabe22932bbe46c079a5f", size = 256732, upload-time = "2025-10-24T09:02:51.603Z" },
+    { url = "https://files.pythonhosted.org/packages/25/0e/8cb71fd3ed4ed08c07aec1245aea7bc1b661ba55fd9c392db76f1978d453/pytest_codspeed-4.2.0-py3-none-any.whl", hash = "sha256:e81bbb45c130874ef99aca97929d72682733527a49f84239ba575b5cb843bab0", size = 113726, upload-time = "2025-10-24T09:02:54.785Z" },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "7.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage", extra = ["toml"] },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/f7/c933acc76f5208b3b00089573cf6a2bc26dc80a8aece8f52bb7d6b1855ca/pytest_cov-7.0.0.tar.gz", hash = "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1", size = 54328, upload-time = "2025-09-09T10:57:02.113Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ee/49/1377b49de7d0c1ce41292161ea0f721913fa8722c19fb9c1e3aa0367eecb/pytest_cov-7.0.0-py3-none-any.whl", hash = "sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861", size = 22424, upload-time = "2025-09-09T10:57:00.695Z" },
+]
+
+[[package]]
+name = "pytest-instafail"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/86/bd/e0ba6c3cd20b9aa445f0af229f3a9582cce589f083537978a23e6f14e310/pytest-instafail-0.5.0.tar.gz", hash = "sha256:33a606f7e0c8e646dc3bfee0d5e3a4b7b78ef7c36168cfa1f3d93af7ca706c9e", size = 5849, upload-time = "2023-03-31T17:17:32.161Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/c0/c32dc39fc172e684fdb3d30169843efb65c067be1e12689af4345731126e/pytest_instafail-0.5.0-py3-none-any.whl", hash = "sha256:6855414487e9e4bb76a118ce952c3c27d3866af15487506c4ded92eb72387819", size = 4176, upload-time = "2023-03-31T17:17:30.065Z" },
+]
+
+[[package]]
+name = "pytest-picked"
+version = "0.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ba/e4/51a54dd6638fd4a7c45bb20a737235fd92cbb4d24b5ff681d64ace5d02e9/pytest_picked-0.5.1.tar.gz", hash = "sha256:6634c4356a560a5dc3dba35471865e6eb06bbd356b56b69c540593e9d5620ded", size = 8401, upload-time = "2024-11-06T23:19:52.538Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c6/81/450c017746caab376c4b6700439de9f1cc7d8e1f22dec3c1eb235cd9ad3e/pytest_picked-0.5.1-py3-none-any.whl", hash = "sha256:af65c4763b51dc095ae4bc5073a962406902422ad9629c26d8b01122b677d998", size = 6608, upload-time = "2024-11-06T23:19:51.284Z" },
+]
+
+[[package]]
+name = "pytest-pretty"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ba/d7/c699e0be5401fe9ccad484562f0af9350b4e48c05acf39fb3dab1932128f/pytest_pretty-1.3.0.tar.gz", hash = "sha256:97e9921be40f003e40ae78db078d4a0c1ea42bf73418097b5077970c2cc43bf3", size = 219297, upload-time = "2025-06-04T12:54:37.322Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/85/2f97a1b65178b0f11c9c77c35417a4cc5b99a80db90dad4734a129844ea5/pytest_pretty-1.3.0-py3-none-any.whl", hash = "sha256:074b9d5783cef9571494543de07e768a4dda92a3e85118d6c7458c67297159b7", size = 5620, upload-time = "2025-06-04T12:54:36.229Z" },
+]
+
+[[package]]
+name = "pytest-sugar"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "termcolor" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0b/4e/60fed105549297ba1a700e1ea7b828044842ea27d72c898990510b79b0e2/pytest-sugar-1.1.1.tar.gz", hash = "sha256:73b8b65163ebf10f9f671efab9eed3d56f20d2ca68bda83fa64740a92c08f65d", size = 16533, upload-time = "2025-08-23T12:19:35.737Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/d5/81d38a91c1fdafb6711f053f5a9b92ff788013b19821257c2c38c1e132df/pytest_sugar-1.1.1-py3-none-any.whl", hash = "sha256:2f8319b907548d5b9d03a171515c1d43d2e38e32bd8182a1781eb20b43344cc8", size = 11440, upload-time = "2025-08-23T12:19:34.894Z" },
+]
+
+[[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -954,6 +1198,31 @@ wheels = [
 ]
 
 [[package]]
+name = "respx"
+version = "0.22.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f4/7c/96bd0bc759cf009675ad1ee1f96535edcb11e9666b985717eb8c87192a95/respx-0.22.0.tar.gz", hash = "sha256:3c8924caa2a50bd71aefc07aa812f2466ff489f1848c96e954a5362d17095d91", size = 28439, upload-time = "2024-12-19T22:33:59.374Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/67/afbb0978d5399bc9ea200f1d4489a23c9a1dad4eee6376242b8182389c79/respx-0.22.0-py2.py3-none-any.whl", hash = "sha256:631128d4c9aba15e56903fb5f66fb1eff412ce28dd387ca3a81339e52dbd3ad0", size = 25127, upload-time = "2024-12-19T22:33:57.837Z" },
+]
+
+[[package]]
+name = "rich"
+version = "14.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fb/d2/8920e102050a0de7bfabeb4c4614a49248cf8d5d7a8d01885fbb24dc767a/rich-14.2.0.tar.gz", hash = "sha256:73ff50c7c0c1c77c8243079283f4edb376f0f6442433aecb8ce7e6d0b92d1fe4", size = 219990, upload-time = "2025-10-09T14:16:53.064Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/25/7a/b0178788f8dc6cafce37a212c99565fa1fe7872c70c6c9c1e1a372d9d88f/rich-14.2.0-py3-none-any.whl", hash = "sha256:76bc51fe2e57d2b1be1f96c524b890b816e334ab4c1e45888799bfaab0021edd", size = 243393, upload-time = "2025-10-09T14:16:51.245Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.14.13"
 source = { registry = "https://pypi.org/simple" }
@@ -1010,6 +1279,69 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/44/cd/a040c4b3119bbe532e5b0732286f805445375489fceaec1f48306068ee3b/smmap-5.0.2.tar.gz", hash = "sha256:26ea65a03958fa0c8a1c7e8c7a58fdc77221b8910f6be2131affade476898ad5", size = 22329, upload-time = "2025-01-02T07:14:40.909Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/be/d09147ad1ec7934636ad912901c5fd7667e1c858e19d355237db0d0cd5e4/smmap-5.0.2-py3-none-any.whl", hash = "sha256:b30115f0def7d7531d22a0fb6502488d879e75b260a9db4d0819cfb25403af5e", size = 24303, upload-time = "2025-01-02T07:14:38.724Z" },
+]
+
+[[package]]
+name = "termcolor"
+version = "3.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/79/cf31d7a93a8fdc6aa0fbb665be84426a8c5a557d9240b6239e9e11e35fc5/termcolor-3.3.0.tar.gz", hash = "sha256:348871ca648ec6a9a983a13ab626c0acce02f515b9e1983332b17af7979521c5", size = 14434, upload-time = "2025-12-29T12:55:21.882Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/d1/8bb87d21e9aeb323cc03034f5eaf2c8f69841e40e4853c2627edf8111ed3/termcolor-3.3.0-py3-none-any.whl", hash = "sha256:cf642efadaf0a8ebbbf4bc7a31cec2f9b5f21a9f726f4ccbb08192c9c26f43a5", size = 7734, upload-time = "2025-12-29T12:55:20.718Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/30/31573e9457673ab10aa432461bee537ce6cef177667deca369efb79df071/tomli-2.4.0.tar.gz", hash = "sha256:aa89c3f6c277dd275d8e243ad24f3b5e701491a860d5121f2cdd399fbb31fc9c", size = 17477, upload-time = "2026-01-11T11:22:38.165Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/d9/3dc2289e1f3b32eb19b9785b6a006b28ee99acb37d1d47f78d4c10e28bf8/tomli-2.4.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b5ef256a3fd497d4973c11bf142e9ed78b150d36f5773f1ca6088c230ffc5867", size = 153663, upload-time = "2026-01-11T11:21:45.27Z" },
+    { url = "https://files.pythonhosted.org/packages/51/32/ef9f6845e6b9ca392cd3f64f9ec185cc6f09f0a2df3db08cbe8809d1d435/tomli-2.4.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5572e41282d5268eb09a697c89a7bee84fae66511f87533a6f88bd2f7b652da9", size = 148469, upload-time = "2026-01-11T11:21:46.873Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/c2/506e44cce89a8b1b1e047d64bd495c22c9f71f21e05f380f1a950dd9c217/tomli-2.4.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:551e321c6ba03b55676970b47cb1b73f14a0a4dce6a3e1a9458fd6d921d72e95", size = 236039, upload-time = "2026-01-11T11:21:48.503Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/40/e1b65986dbc861b7e986e8ec394598187fa8aee85b1650b01dd925ca0be8/tomli-2.4.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5e3f639a7a8f10069d0e15408c0b96a2a828cfdec6fca05296ebcdcc28ca7c76", size = 243007, upload-time = "2026-01-11T11:21:49.456Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/6f/6e39ce66b58a5b7ae572a0f4352ff40c71e8573633deda43f6a379d56b3e/tomli-2.4.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1b168f2731796b045128c45982d3a4874057626da0e2ef1fdd722848b741361d", size = 240875, upload-time = "2026-01-11T11:21:50.755Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/ad/cb089cb190487caa80204d503c7fd0f4d443f90b95cf4ef5cf5aa0f439b0/tomli-2.4.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:133e93646ec4300d651839d382d63edff11d8978be23da4cc106f5a18b7d0576", size = 246271, upload-time = "2026-01-11T11:21:51.81Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/63/69125220e47fd7a3a27fd0de0c6398c89432fec41bc739823bcc66506af6/tomli-2.4.0-cp311-cp311-win32.whl", hash = "sha256:b6c78bdf37764092d369722d9946cb65b8767bfa4110f902a1b2542d8d173c8a", size = 96770, upload-time = "2026-01-11T11:21:52.647Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/0d/a22bb6c83f83386b0008425a6cd1fa1c14b5f3dd4bad05e98cf3dbbf4a64/tomli-2.4.0-cp311-cp311-win_amd64.whl", hash = "sha256:d3d1654e11d724760cdb37a3d7691f0be9db5fbdaef59c9f532aabf87006dbaa", size = 107626, upload-time = "2026-01-11T11:21:53.459Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/6d/77be674a3485e75cacbf2ddba2b146911477bd887dda9d8c9dfb2f15e871/tomli-2.4.0-cp311-cp311-win_arm64.whl", hash = "sha256:cae9c19ed12d4e8f3ebf46d1a75090e4c0dc16271c5bce1c833ac168f08fb614", size = 94842, upload-time = "2026-01-11T11:21:54.831Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/43/7389a1869f2f26dba52404e1ef13b4784b6b37dac93bac53457e3ff24ca3/tomli-2.4.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:920b1de295e72887bafa3ad9f7a792f811847d57ea6b1215154030cf131f16b1", size = 154894, upload-time = "2026-01-11T11:21:56.07Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/05/2f9bf110b5294132b2edf13fe6ca6ae456204f3d749f623307cbb7a946f2/tomli-2.4.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7d6d9a4aee98fac3eab4952ad1d73aee87359452d1c086b5ceb43ed02ddb16b8", size = 149053, upload-time = "2026-01-11T11:21:57.467Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/41/1eda3ca1abc6f6154a8db4d714a4d35c4ad90adc0bcf700657291593fbf3/tomli-2.4.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:36b9d05b51e65b254ea6c2585b59d2c4cb91c8a3d91d0ed0f17591a29aaea54a", size = 243481, upload-time = "2026-01-11T11:21:58.661Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/6d/02ff5ab6c8868b41e7d4b987ce2b5f6a51d3335a70aa144edd999e055a01/tomli-2.4.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1c8a885b370751837c029ef9bc014f27d80840e48bac415f3412e6593bbc18c1", size = 251720, upload-time = "2026-01-11T11:22:00.178Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/57/0405c59a909c45d5b6f146107c6d997825aa87568b042042f7a9c0afed34/tomli-2.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8768715ffc41f0008abe25d808c20c3d990f42b6e2e58305d5da280ae7d1fa3b", size = 247014, upload-time = "2026-01-11T11:22:01.238Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/0e/2e37568edd944b4165735687cbaf2fe3648129e440c26d02223672ee0630/tomli-2.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7b438885858efd5be02a9a133caf5812b8776ee0c969fea02c45e8e3f296ba51", size = 251820, upload-time = "2026-01-11T11:22:02.727Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/1c/ee3b707fdac82aeeb92d1a113f803cf6d0f37bdca0849cb489553e1f417a/tomli-2.4.0-cp312-cp312-win32.whl", hash = "sha256:0408e3de5ec77cc7f81960c362543cbbd91ef883e3138e81b729fc3eea5b9729", size = 97712, upload-time = "2026-01-11T11:22:03.777Z" },
+    { url = "https://files.pythonhosted.org/packages/69/13/c07a9177d0b3bab7913299b9278845fc6eaaca14a02667c6be0b0a2270c8/tomli-2.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:685306e2cc7da35be4ee914fd34ab801a6acacb061b6a7abca922aaf9ad368da", size = 108296, upload-time = "2026-01-11T11:22:04.86Z" },
+    { url = "https://files.pythonhosted.org/packages/18/27/e267a60bbeeee343bcc279bb9e8fbed0cbe224bc7b2a3dc2975f22809a09/tomli-2.4.0-cp312-cp312-win_arm64.whl", hash = "sha256:5aa48d7c2356055feef06a43611fc401a07337d5b006be13a30f6c58f869e3c3", size = 94553, upload-time = "2026-01-11T11:22:05.854Z" },
+    { url = "https://files.pythonhosted.org/packages/34/91/7f65f9809f2936e1f4ce6268ae1903074563603b2a2bd969ebbda802744f/tomli-2.4.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:84d081fbc252d1b6a982e1870660e7330fb8f90f676f6e78b052ad4e64714bf0", size = 154915, upload-time = "2026-01-11T11:22:06.703Z" },
+    { url = "https://files.pythonhosted.org/packages/20/aa/64dd73a5a849c2e8f216b755599c511badde80e91e9bc2271baa7b2cdbb1/tomli-2.4.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:9a08144fa4cba33db5255f9b74f0b89888622109bd2776148f2597447f92a94e", size = 149038, upload-time = "2026-01-11T11:22:07.56Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/8a/6d38870bd3d52c8d1505ce054469a73f73a0fe62c0eaf5dddf61447e32fa/tomli-2.4.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c73add4bb52a206fd0c0723432db123c0c75c280cbd67174dd9d2db228ebb1b4", size = 242245, upload-time = "2026-01-11T11:22:08.344Z" },
+    { url = "https://files.pythonhosted.org/packages/59/bb/8002fadefb64ab2669e5b977df3f5e444febea60e717e755b38bb7c41029/tomli-2.4.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fb2945cbe303b1419e2706e711b7113da57b7db31ee378d08712d678a34e51e", size = 250335, upload-time = "2026-01-11T11:22:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/3d/4cdb6f791682b2ea916af2de96121b3cb1284d7c203d97d92d6003e91c8d/tomli-2.4.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bbb1b10aa643d973366dc2cb1ad94f99c1726a02343d43cbc011edbfac579e7c", size = 245962, upload-time = "2026-01-11T11:22:11.27Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/4a/5f25789f9a460bd858ba9756ff52d0830d825b458e13f754952dd15fb7bb/tomli-2.4.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4cbcb367d44a1f0c2be408758b43e1ffb5308abe0ea222897d6bfc8e8281ef2f", size = 250396, upload-time = "2026-01-11T11:22:12.325Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/2f/b73a36fea58dfa08e8b3a268750e6853a6aac2a349241a905ebd86f3047a/tomli-2.4.0-cp313-cp313-win32.whl", hash = "sha256:7d49c66a7d5e56ac959cb6fc583aff0651094ec071ba9ad43df785abc2320d86", size = 97530, upload-time = "2026-01-11T11:22:13.865Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/af/ca18c134b5d75de7e8dc551c5234eaba2e8e951f6b30139599b53de9c187/tomli-2.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:3cf226acb51d8f1c394c1b310e0e0e61fecdd7adcb78d01e294ac297dd2e7f87", size = 108227, upload-time = "2026-01-11T11:22:15.224Z" },
+    { url = "https://files.pythonhosted.org/packages/22/c3/b386b832f209fee8073c8138ec50f27b4460db2fdae9ffe022df89a57f9b/tomli-2.4.0-cp313-cp313-win_arm64.whl", hash = "sha256:d20b797a5c1ad80c516e41bc1fb0443ddb5006e9aaa7bda2d71978346aeb9132", size = 94748, upload-time = "2026-01-11T11:22:16.009Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/c4/84047a97eb1004418bc10bdbcfebda209fca6338002eba2dc27cc6d13563/tomli-2.4.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:26ab906a1eb794cd4e103691daa23d95c6919cc2fa9160000ac02370cc9dd3f6", size = 154725, upload-time = "2026-01-11T11:22:17.269Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/5d/d39038e646060b9d76274078cddf146ced86dc2b9e8bbf737ad5983609a0/tomli-2.4.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:20cedb4ee43278bc4f2fee6cb50daec836959aadaf948db5172e776dd3d993fc", size = 148901, upload-time = "2026-01-11T11:22:18.287Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e5/383be1724cb30f4ce44983d249645684a48c435e1cd4f8b5cded8a816d3c/tomli-2.4.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:39b0b5d1b6dd03684b3fb276407ebed7090bbec989fa55838c98560c01113b66", size = 243375, upload-time = "2026-01-11T11:22:19.154Z" },
+    { url = "https://files.pythonhosted.org/packages/31/f0/bea80c17971c8d16d3cc109dc3585b0f2ce1036b5f4a8a183789023574f2/tomli-2.4.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a26d7ff68dfdb9f87a016ecfd1e1c2bacbe3108f4e0f8bcd2228ef9a766c787d", size = 250639, upload-time = "2026-01-11T11:22:20.168Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/8f/2853c36abbb7608e3f945d8a74e32ed3a74ee3a1f468f1ffc7d1cb3abba6/tomli-2.4.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:20ffd184fb1df76a66e34bd1b36b4a4641bd2b82954befa32fe8163e79f1a702", size = 246897, upload-time = "2026-01-11T11:22:21.544Z" },
+    { url = "https://files.pythonhosted.org/packages/49/f0/6c05e3196ed5337b9fe7ea003e95fd3819a840b7a0f2bf5a408ef1dad8ed/tomli-2.4.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:75c2f8bbddf170e8effc98f5e9084a8751f8174ea6ccf4fca5398436e0320bc8", size = 254697, upload-time = "2026-01-11T11:22:23.058Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/f5/2922ef29c9f2951883525def7429967fc4d8208494e5ab524234f06b688b/tomli-2.4.0-cp314-cp314-win32.whl", hash = "sha256:31d556d079d72db7c584c0627ff3a24c5d3fb4f730221d3444f3efb1b2514776", size = 98567, upload-time = "2026-01-11T11:22:24.033Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/31/22b52e2e06dd2a5fdbc3ee73226d763b184ff21fc24e20316a44ccc4d96b/tomli-2.4.0-cp314-cp314-win_amd64.whl", hash = "sha256:43e685b9b2341681907759cf3a04e14d7104b3580f808cfde1dfdb60ada85475", size = 108556, upload-time = "2026-01-11T11:22:25.378Z" },
+    { url = "https://files.pythonhosted.org/packages/48/3d/5058dff3255a3d01b705413f64f4306a141a8fd7a251e5a495e3f192a998/tomli-2.4.0-cp314-cp314-win_arm64.whl", hash = "sha256:3d895d56bd3f82ddd6faaff993c275efc2ff38e52322ea264122d72729dca2b2", size = 96014, upload-time = "2026-01-11T11:22:26.138Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/4e/75dab8586e268424202d3a1997ef6014919c941b50642a1682df43204c22/tomli-2.4.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:5b5807f3999fb66776dbce568cc9a828544244a8eb84b84b9bafc080c99597b9", size = 163339, upload-time = "2026-01-11T11:22:27.143Z" },
+    { url = "https://files.pythonhosted.org/packages/06/e3/b904d9ab1016829a776d97f163f183a48be6a4deb87304d1e0116a349519/tomli-2.4.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c084ad935abe686bd9c898e62a02a19abfc9760b5a79bc29644463eaf2840cb0", size = 159490, upload-time = "2026-01-11T11:22:28.399Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/5a/fc3622c8b1ad823e8ea98a35e3c632ee316d48f66f80f9708ceb4f2a0322/tomli-2.4.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0f2e3955efea4d1cfbcb87bc321e00dc08d2bcb737fd1d5e398af111d86db5df", size = 269398, upload-time = "2026-01-11T11:22:29.345Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/33/62bd6152c8bdd4c305ad9faca48f51d3acb2df1f8791b1477d46ff86e7f8/tomli-2.4.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0e0fe8a0b8312acf3a88077a0802565cb09ee34107813bba1c7cd591fa6cfc8d", size = 276515, upload-time = "2026-01-11T11:22:30.327Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/ff/ae53619499f5235ee4211e62a8d7982ba9e439a0fb4f2f351a93d67c1dd2/tomli-2.4.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:413540dce94673591859c4c6f794dfeaa845e98bf35d72ed59636f869ef9f86f", size = 273806, upload-time = "2026-01-11T11:22:32.56Z" },
+    { url = "https://files.pythonhosted.org/packages/47/71/cbca7787fa68d4d0a9f7072821980b39fbb1b6faeb5f5cf02f4a5559fa28/tomli-2.4.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:0dc56fef0e2c1c470aeac5b6ca8cc7b640bb93e92d9803ddaf9ea03e198f5b0b", size = 281340, upload-time = "2026-01-11T11:22:33.505Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/00/d595c120963ad42474cf6ee7771ad0d0e8a49d0f01e29576ee9195d9ecdf/tomli-2.4.0-cp314-cp314t-win32.whl", hash = "sha256:d878f2a6707cc9d53a1be1414bbb419e629c3d6e67f69230217bb663e76b5087", size = 108106, upload-time = "2026-01-11T11:22:34.451Z" },
+    { url = "https://files.pythonhosted.org/packages/de/69/9aa0c6a505c2f80e519b43764f8b4ba93b5a0bbd2d9a9de6e2b24271b9a5/tomli-2.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:2add28aacc7425117ff6364fe9e06a183bb0251b03f986df0e78e974047571fd", size = 120504, upload-time = "2026-01-11T11:22:35.764Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/9f/f1668c281c58cfae01482f7114a4b88d345e4c140386241a1a24dcc9e7bc/tomli-2.4.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2b1e3b80e1d5e52e40e9b924ec43d81570f0e7d09d11081b797bc4692765a3d4", size = 99561, upload-time = "2026-01-11T11:22:36.624Z" },
+    { url = "https://files.pythonhosted.org/packages/23/d1/136eb2cb77520a31e1f64cbae9d33ec6df0d78bdf4160398e86eec8a8754/tomli-2.4.0-py3-none-any.whl", hash = "sha256:1f776e7d669ebceb01dee46484485f43a4048746235e683bcdffacdf1fb4785a", size = 14477, upload-time = "2026-01-11T11:22:37.446Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
added unit tests and configured ci to enforce a minimum 80% code coverage threshold.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved HTTP/3 protocol handling with enhanced Alt-Svc header parsing, supporting optional parameters and more resilient quote handling to accommodate various header format variations.

* **Tests**
  * Comprehensive test coverage added across all core modules to ensure reliability and validate functionality.

* **Chores**
  * Added pytest configuration with coverage enforcement (80% minimum), integrated pre-commit hooks for automated testing, and expanded development tooling for enhanced code quality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->